### PR TITLE
[feat/#3] 후처리 STT 기반 결정사항 추출 파이프라인 연동

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,1 @@
+"""API layer (router composition and HTTP endpoints)."""

--- a/app/api/endpoints/__init__.py
+++ b/app/api/endpoints/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level endpoints such as health checks."""

--- a/app/api/endpoints/health.py
+++ b/app/api/endpoints/health.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter
+
+from app.core.responses import ApiResponse, ok_response
+
+router = APIRouter(tags=["system"])
+
+
+@router.get("/")
+def read_root() -> ApiResponse[dict[str, str]]:
+    return ok_response(
+        {"message": "FastAPI server is running"},
+        code="SYSTEM_200",
+        message="서버 상태 조회에 성공했습니다.",
+    )
+
+
+@router.get("/health")
+def health_check() -> ApiResponse[dict[str, str]]:
+    return ok_response(
+        {"status": "ok"},
+        code="SYSTEM_200",
+        message="헬스체크에 성공했습니다.",
+    )

--- a/app/api/router.py
+++ b/app/api/router.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+from app.api.endpoints.health import router as health_router
+from app.domains.decision.router import router as decision_router
+from app.domains.transcribe.router import router as transcribe_router
+
+api_router = APIRouter()
+api_router.include_router(health_router)
+api_router.include_router(transcribe_router, prefix="/api")
+api_router.include_router(decision_router, prefix="/api")

--- a/app/domains/decision/__init__.py
+++ b/app/domains/decision/__init__.py
@@ -1,0 +1,1 @@
+"""Decision domain."""

--- a/app/domains/decision/router.py
+++ b/app/domains/decision/router.py
@@ -1,0 +1,94 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Body
+
+from app.core.responses import ApiErrorResponse, ApiResponse, ok_response
+from app.domains.decision.schemas import (
+    DecisionExtractRequest,
+    DecisionExtractResponse,
+)
+from app.domains.decision.services.extraction import extract_decisions
+
+router = APIRouter(prefix="/decisions", tags=["decision"])
+
+
+@router.post(
+    "/extract",
+    response_model=ApiResponse[DecisionExtractResponse],
+    summary="전사 세그먼트 기반 의사결정 재추출",
+    description=(
+        "저장된 transcript_segments(JSON)만으로 "
+        "의사결정 결과를 추출합니다. "
+        "오디오 재업로드 없이 프롬프트 변경 실험, "
+        "실패 재시도, 운영 재처리에 사용합니다.\n\n"
+        "팀 공유 FAQ:\n"
+        "- timeline.speaker_id가 null일 수 있습니다(오탐 방지 목적).\n"
+        "- summary_ready 단계 값과 completed 단계 값은 일부 필드가 다를 수 있습니다.\n"
+        "- 이 API는 completed 결과 재생성/프롬프트 재실험 용도로 권장합니다."
+    ),
+    responses={
+        422: {
+            "model": ApiErrorResponse,
+            "description": "요청 스키마 검증 실패(예: transcript_segments 누락).",
+        },
+        500: {
+            "model": ApiErrorResponse,
+            "description": "서버 설정 오류(예: GEMINI_API_KEY 누락).",
+        },
+        502: {
+            "model": ApiErrorResponse,
+            "description": "Gemini 연결/응답/JSON 파싱 오류.",
+        },
+    },
+)
+async def extract_decisions_from_transcript(
+    payload: Annotated[
+        DecisionExtractRequest,
+        Body(
+            description=(
+                "Spring 연동 가이드:\n"
+                "- 본 API는 오디오 업로드 없이, 이미 저장된 transcript_segments로 "
+                "의사결정을 재추출/재시도할 때 사용합니다.\n"
+                "- 요청 본문은 반드시 객체형(JSON object)이며 "
+                "transcript_segments 필드를 포함해야 합니다.\n"
+                "- meeting_id/project_id는 선택이며, "
+                "전달 시 응답에 그대로 포함됩니다.\n"
+                "- 권장 입력은 /api/transcribe 계열 응답의 "
+                "transcript_segments 원본입니다."
+            ),
+            examples={
+                "object_with_metadata": {
+                    "summary": "권장: 메타데이터 + STT 세그먼트",
+                    "value": {
+                        "meeting_id": "meeting-123",
+                        "project_id": "project-abc",
+                        "transcript_segments": [
+                            {
+                                "message_id": 1,
+                                "speaker": "Speaker 0",
+                                "start_time": "00:00:00",
+                                "end_time": "00:00:03",
+                                "text": (
+                                    "이번 주에는 배포 방식을 단순화하기로 합의했습니다."
+                                ),
+                                "is_final": True,
+                            }
+                        ],
+                    },
+                },
+            },
+        ),
+    ],
+) -> ApiResponse[DecisionExtractResponse]:
+    # 전달받은 전사 세그먼트로 의사결정 결과를 재추출
+    decision_result = await extract_decisions(payload.transcript_segments)
+
+    return ok_response(
+        DecisionExtractResponse(
+            meeting_id=payload.meeting_id,
+            project_id=payload.project_id,
+            decision_result=decision_result,
+        ),
+        code="DECISION_200",
+        message="의사결정 재추출이 완료되었습니다.",
+    )

--- a/app/domains/decision/schemas.py
+++ b/app/domains/decision/schemas.py
@@ -1,0 +1,100 @@
+from pydantic import BaseModel, Field
+
+from app.domains.transcribe.schemas import TranscribeSegment
+
+
+class MeetingInfo(BaseModel):
+    title: str = Field(default="", description="회의 제목")
+    purpose: str = Field(default="", description="회의 목적")
+    duration: str = Field(default="", description="회의 길이/시간")
+
+
+class OverallAnalysis(BaseModel):
+    meeting_info: MeetingInfo = Field(default_factory=MeetingInfo)
+    topics: list[str] = Field(default_factory=list, description="논의된 주제 목록")
+    core_context: list[str] = Field(
+        default_factory=list, description="프로젝트 배경/제약 컨텍스트"
+    )
+    final_decisions_list: list[str] = Field(
+        default_factory=list,
+        description=(
+            "최종 결정사항 제목 목록. "
+            "비동기 실행의 summary_ready 단계에서는 임시값일 수 있으며, "
+            "completed 단계에서 decision_cards 기준으로 재동기화될 수 있습니다."
+        ),
+    )
+    all_decision_reasons: list[str] = Field(
+        default_factory=list,
+        description="결정 근거 통합 목록(문장 단위)",
+    )
+
+
+class DecisionTimelineItem(BaseModel):
+    timestamp: str = Field(description="해당 단계 시각(HH:MM:SS)")
+    step: str = Field(description="이슈제기/대안논의/최종합의")
+    speaker_id: str | None = Field(
+        default=None,
+        description=(
+            '타임라인 발화 화자 ID(예: "Speaker 0"). '
+            "짧은 응답어(예: 네/확인)처럼 화자 추정 신뢰도가 낮은 경우 "
+            "억지 매핑을 피하기 위해 null로 반환될 수 있습니다. "
+            'UI에서는 "미확인 화자" 등으로 표시를 권장합니다.'
+        ),
+    )
+    content: str = Field(description="타임라인 요약 한 문장")
+    utterance: str = Field(description="실제 발화 원문")
+
+
+class DecisionCard(BaseModel):
+    decision_title: str = Field(description="결정사항 제목")
+    applied_items: list[str] = Field(default_factory=list, description="액션 아이템")
+    decision_reasons: list[str] = Field(
+        default_factory=list,
+        description="해당 결정의 근거 목록(1근거=1문장)",
+    )
+    timeline: list[DecisionTimelineItem] = Field(
+        default_factory=list,
+        description="결정 타임라인(이슈제기→대안논의→최종합의)",
+    )
+
+
+class DecisionExtractionResult(BaseModel):
+    overall_analysis: OverallAnalysis = Field(default_factory=OverallAnalysis)
+    decision_cards: list[DecisionCard] = Field(
+        default_factory=list,
+        description="결정사항 카드 목록",
+    )
+    other_mentions: list[str] = Field(
+        default_factory=list,
+        description="결정으로 확정되지 않은 기술 제언/추가 과제",
+    )
+
+
+class DecisionExtractRequest(BaseModel):
+    meeting_id: str | None = Field(
+        default=None,
+        description="호출 측(예: Spring)에서 관리하는 회의 ID(선택)",
+    )
+    project_id: str | None = Field(
+        default=None,
+        description="호출 측(예: Spring)에서 관리하는 프로젝트 ID(선택)",
+    )
+    transcript_segments: list[TranscribeSegment] = Field(
+        description=(
+            "후처리 완료 전사 세그먼트 배열. "
+            "원칙적으로 /api/transcribe 또는 /api/transcribe/decisions 계열에서 "
+            "생성된 포맷을 그대로 전달하는 것을 권장합니다."
+        )
+    )
+
+
+class DecisionExtractResponse(BaseModel):
+    meeting_id: str | None = Field(
+        default=None,
+        description="요청에서 전달받은 meeting_id echo",
+    )
+    project_id: str | None = Field(
+        default=None,
+        description="요청에서 전달받은 project_id echo",
+    )
+    decision_result: DecisionExtractionResult

--- a/app/domains/decision/services/__init__.py
+++ b/app/domains/decision/services/__init__.py
@@ -1,0 +1,1 @@
+"""Decision domain services."""

--- a/app/domains/decision/services/extraction.py
+++ b/app/domains/decision/services/extraction.py
@@ -1,0 +1,501 @@
+import json
+import logging
+import os
+import re
+
+from google import genai
+from google.genai import types
+from pydantic import BaseModel, Field
+
+from app.core.errors import AppServiceError
+from app.domains.decision.schemas import (
+    DecisionCard,
+    DecisionExtractionResult,
+    OverallAnalysis,
+)
+from app.domains.transcribe.schemas import TranscribeSegment
+
+GEMINI_MODEL = "gemini-3.1-flash-lite-preview"
+logger = logging.getLogger(__name__)
+AMBIGUOUS_SHORT_UTTERANCES = {
+    "네",
+    "예",
+    "응",
+    "음",
+    "어",
+    "맞아요",
+    "맞습니다",
+    "아니요",
+    "확인",
+    "오케이",
+    "ok",
+    "okay",
+}
+
+DECISION_POLICY_PROMPT = "\n".join(
+    [
+        "당신은 Whylog 프로젝트의 수석 분석가입니다.",
+        "아래 STT 데이터를 바탕으로 'Whylog 3대 운영 정책'을",
+        "엄격히 준수하여 분석을 수행하세요.",
+        "",
+        "------------------------------------------------------------",
+        "[정책 1: 회의 종료 시 Decision 생성 정책]",
+        "1. 명확한 선택지 수렴, 기술/구조/정책/프로세스 변경 합의,",
+        '   "~하기로 한다"는 명시적 결론이 있을 때만 Decision을 생성한다.',
+        "2. 단순 의견 교환, 결론 없는 토론, 감정 표현, 농담/잡담은",
+        "   절대 생성하지 않는다.",
+        "3. 주제가 다르면 별도 Decision으로 분리하고,",
+        "   모호한 경우 생성하지 말고 보류 처리한다.",
+        "",
+        "[정책 2: 결정(Decision) 근거 정책]",
+        "1. 기술적/비용적/운영적 이유, 리스크 판단,",
+        "   성능/확장성/안정성 관련 판단을 포함한다.",
+        "2. 감정적 반응, 농담, 단순 동의는 제외한다.",
+        "3. 동일 의미 발언은 병합하고 구어체는 서술형으로 정제한다.",
+        "4. 반드시 '1 근거 = 1 문장' 원칙을 준수한다.",
+        "   (리스트의 각 항목은 한 문장이어야 함)",
+        "",
+        "[정책 3: Decision 타임라인 정책]",
+        "1. 이슈 제기 -> 대안 논의 -> 최종 합의 시점 순으로 구성한다.",
+        "2. Decision과 직접 관련된 흐름만 표시하고 단순 발언은 제외한다.",
+        "3. 반드시 실제 발화(Utterance) 원문과 화자 ID를 포함한다.",
+        "4. timeline의 content는 간략한 한 문장으로 작성한다.",
+        "------------------------------------------------------------",
+        "",
+        "[출력 JSON 구조]:",
+        "{",
+        '  "overall_analysis": {',
+        '    "meeting_info": { "title": "...", "purpose": "...", "duration": "..." },',
+        '    "topics": ["논의된 모든 주제 리스트"],',
+        '    "core_context": ["프로젝트 배경 및 제약 사항"],',
+        '    "final_decisions_list": ["생성된 모든 결정사항 타이틀 리스트"],',
+        '    "all_decision_reasons": [',
+        '      "모든 결정사항의 근거를 통합하여 정렬한 리스트"',
+        "    ]",
+        "  },",
+        '  "decision_cards": [',
+        "    {",
+        '      "decision_title": "결정 사항 명칭",',
+        '      "applied_items": ["수행해야 할 액션 아이템"],',
+        '      "decision_reasons": ["해당 결정의 근거 (1근거=1문장)"],',
+        '      "timeline": [',
+        "        {",
+        '          "timestamp": "...",',
+        '          "step": "이슈제기/대안논의/최종합의",',
+        '          "speaker_id": "Speaker 0",',
+        '          "content": "간략 요약 한 문장",',
+        '          "utterance": "실제 발화 원문"',
+        "        }",
+        "      ]",
+        "    }",
+        "  ],",
+        '  "other_mentions": ["결정되지 않은 기술적 제언 및 미래 과제"]',
+        "}",
+    ]
+)
+
+SUMMARY_ONLY_PROMPT = "\n".join(
+    [
+        "당신은 Whylog 프로젝트의 수석 분석가입니다.",
+        "아래 STT 데이터를 바탕으로 회의 요약 정보만 구조화하세요.",
+        "",
+        "[핵심 규칙]",
+        "1. 실제 회의 내용 기반으로만 작성하고 추측하지 않는다.",
+        "2. final_decisions_list에는 실제 합의된 결정만 넣는다.",
+        "3. all_decision_reasons는 근거를 문장 단위로 정리한다.",
+        "",
+        "[출력 JSON 구조]",
+        "{",
+        '  "overall_analysis": {',
+        '    "meeting_info": { "title": "...", "purpose": "...", "duration": "..." },',
+        '    "topics": ["논의된 모든 주제 리스트"],',
+        '    "core_context": ["프로젝트 배경 및 제약 사항"],',
+        '    "final_decisions_list": ["생성된 모든 결정사항 타이틀 리스트"],',
+        '    "all_decision_reasons": [',
+        '      "모든 결정사항의 근거를 통합하여 정렬한 리스트"',
+        "    ]",
+        "  }",
+        "}",
+    ]
+)
+
+DECISION_CARDS_ONLY_PROMPT = "\n".join(
+    [
+        "당신은 Whylog 프로젝트의 수석 분석가입니다.",
+        "아래 STT 데이터를 바탕으로 결정사항 카드만 구조화하세요.",
+        "",
+        "[정책 1: Decision 생성]",
+        "1. 명확한 결론이 있는 합의만 decision_cards에 포함한다.",
+        "2. 결론 없는 토론/잡담은 제외한다.",
+        "3. 주제가 다르면 별도 카드로 분리한다.",
+        "",
+        "[정책 2: 근거]",
+        "1. 기술/비용/운영/리스크/성능 관련 근거를 우선한다.",
+        "2. 1 근거 = 1 문장 원칙을 지킨다.",
+        "",
+        "[정책 3: 타임라인]",
+        "1. 이슈제기 -> 대안논의 -> 최종합의 순서를 따른다.",
+        "2. 실제 발화 원문과 화자 ID를 포함한다.",
+        "3. content는 간략한 한 문장으로 작성한다.",
+        "",
+        "[출력 JSON 구조]",
+        "{",
+        '  "decision_cards": [',
+        "    {",
+        '      "decision_title": "결정 사항 명칭",',
+        '      "applied_items": ["수행해야 할 액션 아이템"],',
+        '      "decision_reasons": ["해당 결정의 근거 (1근거=1문장)"],',
+        '      "timeline": [',
+        "        {",
+        '          "timestamp": "...",',
+        '          "step": "이슈제기/대안논의/최종합의",',
+        '          "speaker_id": "Speaker 0",',
+        '          "content": "간략 요약 한 문장",',
+        '          "utterance": "실제 발화 원문"',
+        "        }",
+        "      ]",
+        "    }",
+        "  ],",
+        '  "other_mentions": ["결정되지 않은 기술적 제언 및 미래 과제"]',
+        "}",
+    ]
+)
+
+
+class _SummaryOnlyResponse(BaseModel):
+    overall_analysis: OverallAnalysis = Field(default_factory=OverallAnalysis)
+
+
+class _DecisionCardsOnlyResponse(BaseModel):
+    decision_cards: list[DecisionCard] = Field(default_factory=list)
+    other_mentions: list[str] = Field(default_factory=list)
+
+
+def _clean_json_response(result_text: str) -> str:
+    # 모델 응답에서 코드블록 마크다운을 제거
+    cleaned = re.sub(r"```json|```", "", result_text or "", flags=re.IGNORECASE)
+    return cleaned.strip()
+
+
+def _build_prompt(stt_data: list[dict]) -> str:
+    # 전체 의사결정 추출용 프롬프트 생성
+    stt_json = json.dumps(stt_data, ensure_ascii=False)
+    return (
+        f"{DECISION_POLICY_PROMPT}\n\n"
+        f"[STT 데이터]: {stt_json}\n\n"
+        "반드시 JSON만 반환하세요. 마크다운 코드블록은 사용하지 마세요."
+    )
+
+
+def _build_summary_prompt(stt_data: list[dict]) -> str:
+    # 회의 요약(overall_analysis) 전용 프롬프트 생성
+    stt_json = json.dumps(stt_data, ensure_ascii=False)
+    return (
+        f"{SUMMARY_ONLY_PROMPT}\n\n"
+        f"[STT 데이터]: {stt_json}\n\n"
+        "반드시 JSON만 반환하세요. 마크다운 코드블록은 사용하지 마세요."
+    )
+
+
+def _build_decision_cards_prompt(stt_data: list[dict]) -> str:
+    # decision_cards/other_mentions 전용 프롬프트 생성
+    stt_json = json.dumps(stt_data, ensure_ascii=False)
+    return (
+        f"{DECISION_CARDS_ONLY_PROMPT}\n\n"
+        f"[STT 데이터]: {stt_json}\n\n"
+        "반드시 JSON만 반환하세요. 마크다운 코드블록은 사용하지 마세요."
+    )
+
+
+async def _request_gemini_json(
+    prompt: str,
+    failure_context: str,
+) -> dict:
+    # Gemini 호출 + JSON 응답 파싱을 공통 처리
+    api_key = os.getenv("GEMINI_API_KEY", "")
+    if not api_key:
+        raise AppServiceError(
+            "GEMINI_API_KEY가 설정되지 않았습니다.",
+            status_code=500,
+        )
+
+    client = genai.Client(api_key=api_key)
+    try:
+        response = await client.aio.models.generate_content(
+            model=GEMINI_MODEL,
+            contents=prompt,
+            config=types.GenerateContentConfig(
+                response_mime_type="application/json",
+                temperature=0.1,
+            ),
+        )
+    except Exception as e:
+        raise AppServiceError(
+            f"{failure_context} 요청 실패: {e}",
+            status_code=502,
+        ) from e
+
+    cleaned_json = _clean_json_response(response.text or "")
+    if not cleaned_json:
+        raise AppServiceError(
+            f"{failure_context} 응답이 비어 있습니다.",
+            status_code=502,
+        )
+
+    try:
+        parsed = json.loads(cleaned_json)
+    except Exception as e:
+        raise AppServiceError(
+            f"{failure_context} JSON 파싱 실패: {e}",
+            status_code=502,
+        ) from e
+
+    if not isinstance(parsed, dict):
+        raise AppServiceError(
+            f"{failure_context} 응답 형식이 객체(JSON object)가 아닙니다.",
+            status_code=502,
+        )
+    return parsed
+
+
+def _parse_timestamp_to_seconds(value: str) -> int | None:
+    # HH:MM:SS 문자열을 초 단위 정수로 변환
+    parts = (value or "").strip().split(":")
+    if len(parts) == 2:
+        parts = ["0", *parts]
+    if len(parts) != 3:
+        return None
+    try:
+        hours, minutes, seconds = (int(part) for part in parts)
+    except ValueError:
+        return None
+    return hours * 3600 + minutes * 60 + seconds
+
+
+def _normalize_text(value: str) -> str:
+    # 공백 정규화로 비교 안정성 확보
+    return " ".join((value or "").split())
+
+
+def _is_ambiguous_utterance(value: str) -> bool:
+    # 화자 추정에 쓰기 어려운 짧은/모호 발화 여부 판단
+    normalized = _normalize_text(value).lower()
+    if not normalized:
+        return True
+    if normalized in AMBIGUOUS_SHORT_UTTERANCES:
+        return True
+    return len(normalized) <= 3
+
+
+def _match_score(utterance: str, segment_text: str) -> int:
+    # utterance와 segment 텍스트의 유사도 점수 계산
+    if not utterance or not segment_text:
+        return 0
+    if utterance == segment_text:
+        return 4
+    if utterance in segment_text:
+        return 3
+    if segment_text in utterance:
+        return 2
+    utterance_tokens = set(utterance.split())
+    segment_tokens = set(segment_text.split())
+    if utterance_tokens and segment_tokens and utterance_tokens & segment_tokens:
+        return 1
+    return 0
+
+
+def _infer_speaker_id(
+    utterance: str,
+    timestamp: str,
+    segments: list[TranscribeSegment],
+    valid_speakers: set[str],
+) -> str | None:
+    # timestamp + utterance 유사도로 timeline 화자를 추정
+    normalized_utterance = _normalize_text(utterance)
+    target_seconds = _parse_timestamp_to_seconds(timestamp)
+    timestamp_candidates: list[TranscribeSegment] = []
+    if target_seconds is not None:
+        for segment in segments:
+            if segment.speaker not in valid_speakers:
+                continue
+            start_seconds = _parse_timestamp_to_seconds(segment.start_time)
+            end_seconds = _parse_timestamp_to_seconds(segment.end_time)
+            if start_seconds is None or end_seconds is None:
+                continue
+            if start_seconds <= target_seconds <= end_seconds:
+                timestamp_candidates.append(segment)
+
+        if len(timestamp_candidates) == 1:
+            return timestamp_candidates[0].speaker
+
+        if len(timestamp_candidates) > 1 and not _is_ambiguous_utterance(
+            normalized_utterance
+        ):
+            scored = sorted(
+                (
+                    (
+                        _match_score(
+                            normalized_utterance,
+                            _normalize_text(segment.text),
+                        ),
+                        segment,
+                    )
+                    for segment in timestamp_candidates
+                ),
+                key=lambda item: item[0],
+                reverse=True,
+            )
+            if scored and scored[0][0] > 0:
+                return scored[0][1].speaker
+
+    if _is_ambiguous_utterance(normalized_utterance):
+        return None
+
+    global_scored = sorted(
+        (
+            (
+                _match_score(
+                    normalized_utterance,
+                    _normalize_text(segment.text),
+                ),
+                segment,
+            )
+            for segment in segments
+            if segment.speaker in valid_speakers
+        ),
+        key=lambda item: item[0],
+        reverse=True,
+    )
+    if global_scored and global_scored[0][0] >= 3:
+        return global_scored[0][1].speaker
+    return None
+
+
+def _normalize_timeline_speaker_ids(
+    result: DecisionExtractionResult,
+    segments: list[TranscribeSegment],
+) -> None:
+    # LLM이 생성한 잘못된 speaker_id를 가능한 범위에서 보정
+    valid_speakers = [segment.speaker for segment in segments if segment.speaker]
+    valid_speaker_set = set(valid_speakers)
+    corrected_count = 0
+    unresolved_count = 0
+
+    for card in result.decision_cards:
+        for item in card.timeline:
+            if item.speaker_id in valid_speaker_set:
+                continue
+
+            inferred = None
+            if valid_speaker_set:
+                inferred = _infer_speaker_id(
+                    utterance=item.utterance,
+                    timestamp=item.timestamp,
+                    segments=segments,
+                    valid_speakers=valid_speaker_set,
+                )
+            if inferred:
+                item.speaker_id = inferred
+                corrected_count += 1
+            else:
+                # 추정이 불가능하면 임의 화자값을 만들지 않고 None으로 둔다.
+                item.speaker_id = None
+                unresolved_count += 1
+
+    if corrected_count > 0:
+        logger.warning(
+            "Normalized %s invalid timeline speaker_id values.",
+            corrected_count,
+        )
+    if unresolved_count > 0:
+        logger.warning(
+            "Could not infer %s timeline speaker_id values.",
+            unresolved_count,
+        )
+
+
+def _synchronize_overall_with_cards(result: DecisionExtractionResult) -> None:
+    # overall_analysis를 decision_cards 기준으로 재정렬/동기화
+    titles = [
+        card.decision_title.strip()
+        for card in result.decision_cards
+        if card.decision_title and card.decision_title.strip()
+    ]
+    reasons: list[str] = []
+    seen_reasons: set[str] = set()
+    for card in result.decision_cards:
+        for reason in card.decision_reasons:
+            normalized_reason = " ".join((reason or "").split())
+            if not normalized_reason:
+                continue
+            if normalized_reason in seen_reasons:
+                continue
+            seen_reasons.add(normalized_reason)
+            reasons.append(normalized_reason)
+
+    result.overall_analysis.final_decisions_list = titles
+    result.overall_analysis.all_decision_reasons = reasons
+
+
+def build_decision_result(
+    overall_analysis: OverallAnalysis,
+    cards_result: DecisionExtractionResult,
+) -> DecisionExtractionResult:
+    # 요약 결과와 카드 결과를 하나의 최종 DTO로 결합
+    result = DecisionExtractionResult(
+        overall_analysis=overall_analysis,
+        decision_cards=cards_result.decision_cards,
+        other_mentions=cards_result.other_mentions,
+    )
+    _synchronize_overall_with_cards(result)
+    return result
+
+
+async def extract_decisions(
+    segments: list[TranscribeSegment],
+) -> DecisionExtractionResult:
+    # 요약 + 카드 추출을 순차 실행해 최종 결과 반환
+    overall_analysis = await extract_overall_analysis(segments)
+    cards_result = await extract_decision_cards_only(segments)
+    return build_decision_result(overall_analysis, cards_result)
+
+
+async def extract_overall_analysis(
+    segments: list[TranscribeSegment],
+) -> OverallAnalysis:
+    # 회의 요약(overall_analysis)만 추출
+    stt_data = [segment.model_dump(mode="json") for segment in segments]
+    prompt = _build_summary_prompt(stt_data)
+    parsed = await _request_gemini_json(prompt, "Gemini 회의 요약 추출")
+
+    try:
+        result = _SummaryOnlyResponse.model_validate(parsed)
+        return result.overall_analysis
+    except Exception as e:
+        raise AppServiceError(
+            f"Gemini 회의 요약 JSON 파싱/검증 실패: {e}",
+            status_code=502,
+        ) from e
+
+
+async def extract_decision_cards_only(
+    segments: list[TranscribeSegment],
+) -> DecisionExtractionResult:
+    # decision_cards/other_mentions만 추출 후 speaker_id 보정
+    stt_data = [segment.model_dump(mode="json") for segment in segments]
+    prompt = _build_decision_cards_prompt(stt_data)
+    parsed = await _request_gemini_json(prompt, "Gemini 결정사항 카드 추출")
+
+    try:
+        cards_result = _DecisionCardsOnlyResponse.model_validate(parsed)
+        result = DecisionExtractionResult(
+            decision_cards=cards_result.decision_cards,
+            other_mentions=cards_result.other_mentions,
+        )
+        _normalize_timeline_speaker_ids(result, segments)
+        return result
+    except Exception as e:
+        raise AppServiceError(
+            f"Gemini 결정사항 카드 JSON 파싱/검증 실패: {e}",
+            status_code=502,
+        ) from e

--- a/app/domains/pipeline/__init__.py
+++ b/app/domains/pipeline/__init__.py
@@ -1,0 +1,1 @@
+"""Pipeline/orchestration domain."""

--- a/app/domains/pipeline/schemas.py
+++ b/app/domains/pipeline/schemas.py
@@ -1,0 +1,77 @@
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from app.domains.decision.schemas import DecisionExtractionResult
+from app.domains.transcribe.schemas import TranscribeSegment
+
+RunStatus = Literal["queued", "processing", "completed", "failed"]
+RunPhase = Literal[
+    "queued",
+    "transcribing",
+    "transcript_ready",
+    "summary_ready",
+    "decisions_ready",
+    "failed",
+]
+
+
+class TranscribeDecisionResponse(BaseModel):
+    meeting_id: str | None = Field(
+        default=None,
+        description="요청에서 전달받은 meeting_id echo",
+    )
+    project_id: str | None = Field(
+        default=None,
+        description="요청에서 전달받은 project_id echo",
+    )
+    transcript_segments: list[TranscribeSegment] = Field(
+        default_factory=list,
+        description="STT + 후처리 완료 세그먼트",
+    )
+    decision_result: DecisionExtractionResult = Field(
+        description="의사결정 추출 결과",
+    )
+
+
+class TranscribeDecisionRunAccepted(BaseModel):
+    run_id: str = Field(description="비동기 실행 식별자")
+    status: RunStatus = Field(description='실행 상태("queued" 고정으로 시작)')
+    phase: RunPhase = Field(description='실행 단계("queued" 고정으로 시작)')
+    meeting_id: str | None = Field(default=None, description="요청 meeting_id echo")
+    project_id: str | None = Field(default=None, description="요청 project_id echo")
+
+
+class TranscribeDecisionRunStatus(BaseModel):
+    run_id: str = Field(description="비동기 실행 식별자")
+    status: RunStatus = Field(description="queued/processing/completed/failed")
+    phase: RunPhase = Field(
+        description=(
+            "queued/transcribing/transcript_ready/summary_ready/"
+            "decisions_ready/failed. "
+            "summary_ready는 요약 정보가 채워진 중간 상태이며, "
+            "decisions_ready(completed)가 최종 상태입니다."
+        )
+    )
+    meeting_id: str | None = Field(default=None, description="요청 meeting_id echo")
+    project_id: str | None = Field(default=None, description="요청 project_id echo")
+    submitted_at: str = Field(description="실행 접수 시각(UTC ISO8601)")
+    started_at: str | None = Field(
+        default=None,
+        description="실행 시작 시각(UTC ISO8601)",
+    )
+    finished_at: str | None = Field(
+        default=None,
+        description="실행 종료 시각(UTC ISO8601)",
+    )
+    error: str | None = Field(default=None, description="실패 시 오류 메시지")
+    result: TranscribeDecisionResponse | None = Field(
+        default=None,
+        description=(
+            "중간/최종 결과. "
+            "transcribing 단계에서는 null, "
+            "transcript_ready에서는 transcript_segments 중심, "
+            "summary_ready에서는 overall_analysis가 추가되며, "
+            "decisions_ready에서는 decision_cards 포함 최종 결과가 채워집니다."
+        ),
+    )

--- a/app/domains/pipeline/services/__init__.py
+++ b/app/domains/pipeline/services/__init__.py
@@ -1,0 +1,1 @@
+"""Pipeline services."""

--- a/app/domains/pipeline/services/decision_runs.py
+++ b/app/domains/pipeline/services/decision_runs.py
@@ -1,0 +1,178 @@
+import asyncio
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+from app.domains.pipeline.schemas import (
+    RunPhase,
+    RunStatus,
+    TranscribeDecisionResponse,
+    TranscribeDecisionRunAccepted,
+    TranscribeDecisionRunStatus,
+)
+
+RUN_TTL = timedelta(hours=24)
+MAX_RUN_RECORDS = 300
+
+
+@dataclass
+class _RunRecord:
+    run_id: str
+    status: RunStatus
+    phase: RunPhase
+    meeting_id: str | None
+    project_id: str | None
+    submitted_at: datetime
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    error: str | None = None
+    result: TranscribeDecisionResponse | None = None
+
+
+_runs: dict[str, _RunRecord] = {}
+_lock = asyncio.Lock()
+
+
+def _utc_now() -> datetime:
+    # UTC 기준 현재 시각 반환
+    return datetime.now(UTC)
+
+
+def _to_iso(value: datetime | None) -> str | None:
+    # datetime을 ISO8601 문자열로 변환
+    return value.isoformat() if value else None
+
+
+def _cleanup_runs_locked() -> None:
+    # TTL/최대 개수 정책에 따라 run 저장소를 정리
+    now = _utc_now()
+    expiry_cutoff = now - RUN_TTL
+
+    expired_ids = []
+    for run_id, run in _runs.items():
+        # 진행 중 실행은 TTL 삭제 대상에서 제외
+        if run.status in {"queued", "processing"}:
+            continue
+        reference_time = run.finished_at or run.submitted_at
+        if reference_time < expiry_cutoff:
+            expired_ids.append(run_id)
+    for run_id in expired_ids:
+        _runs.pop(run_id, None)
+
+    if len(_runs) <= MAX_RUN_RECORDS:
+        return
+
+    overflow = len(_runs) - MAX_RUN_RECORDS
+    eviction_candidates = sorted(
+        (
+            item
+            for item in _runs.items()
+            if item[1].status not in {"queued", "processing"}
+        ),
+        key=lambda item: item[1].submitted_at,
+    )
+    for run_id, _ in eviction_candidates[:overflow]:
+        _runs.pop(run_id, None)
+
+
+def _to_run_status(run: _RunRecord) -> TranscribeDecisionRunStatus:
+    # 내부 저장 레코드를 외부 응답 모델로 변환
+    return TranscribeDecisionRunStatus(
+        run_id=run.run_id,
+        status=run.status,
+        phase=run.phase,
+        meeting_id=run.meeting_id,
+        project_id=run.project_id,
+        submitted_at=run.submitted_at.isoformat(),
+        started_at=_to_iso(run.started_at),
+        finished_at=_to_iso(run.finished_at),
+        error=run.error,
+        result=run.result.model_copy(deep=True) if run.result else None,
+    )
+
+
+async def create_run(
+    meeting_id: str | None,
+    project_id: str | None,
+) -> TranscribeDecisionRunAccepted:
+    # 비동기 파이프라인 실행 레코드를 생성
+    async with _lock:
+        _cleanup_runs_locked()
+        run_id = uuid4().hex
+        _runs[run_id] = _RunRecord(
+            run_id=run_id,
+            status="queued",
+            phase="queued",
+            meeting_id=meeting_id,
+            project_id=project_id,
+            submitted_at=_utc_now(),
+        )
+        return TranscribeDecisionRunAccepted(
+            run_id=run_id,
+            status="queued",
+            phase="queued",
+            meeting_id=meeting_id,
+            project_id=project_id,
+        )
+
+
+async def mark_run_processing(run_id: str) -> None:
+    # run 상태를 처리중(transcribing)으로 전환
+    async with _lock:
+        run = _runs.get(run_id)
+        if not run:
+            return
+        run.status = "processing"
+        run.phase = "transcribing"
+        run.started_at = _utc_now()
+        run.error = None
+
+
+async def mark_run_phase(
+    run_id: str,
+    phase: RunPhase,
+    result: TranscribeDecisionResponse | None = None,
+) -> None:
+    # 단계별 중간 결과를 저장하며 phase 갱신
+    async with _lock:
+        run = _runs.get(run_id)
+        if not run:
+            return
+        run.phase = phase
+        if result is not None:
+            run.result = result.model_copy(deep=True)
+
+
+async def mark_run_completed(run_id: str, result: TranscribeDecisionResponse) -> None:
+    # run을 최종 완료 상태로 전환
+    async with _lock:
+        run = _runs.get(run_id)
+        if not run:
+            return
+        run.status = "completed"
+        run.phase = "decisions_ready"
+        run.result = result.model_copy(deep=True)
+        run.error = None
+        run.finished_at = _utc_now()
+
+
+async def mark_run_failed(run_id: str, error: str) -> None:
+    # run을 실패 상태로 전환하고 오류 메시지 저장
+    async with _lock:
+        run = _runs.get(run_id)
+        if not run:
+            return
+        run.status = "failed"
+        run.phase = "failed"
+        run.error = error
+        run.finished_at = _utc_now()
+
+
+async def get_run_status(run_id: str) -> TranscribeDecisionRunStatus | None:
+    # run 현재 상태/결과를 조회
+    async with _lock:
+        _cleanup_runs_locked()
+        run = _runs.get(run_id)
+        if not run:
+            return None
+        return _to_run_status(run)

--- a/app/domains/transcribe/router.py
+++ b/app/domains/transcribe/router.py
@@ -1,0 +1,428 @@
+import logging
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    File,
+    Form,
+    HTTPException,
+    UploadFile,
+)
+
+from app.core.errors import AppServiceError
+from app.core.responses import ApiErrorResponse, ApiResponse, ok_response
+from app.domains.decision.schemas import DecisionExtractionResult
+from app.domains.decision.services.extraction import (
+    build_decision_result,
+    extract_decision_cards_only,
+    extract_decisions,
+    extract_overall_analysis,
+)
+from app.domains.pipeline.schemas import (
+    TranscribeDecisionResponse,
+    TranscribeDecisionRunAccepted,
+    TranscribeDecisionRunStatus,
+)
+from app.domains.pipeline.services.decision_runs import (
+    create_run,
+    get_run_status,
+    mark_run_completed,
+    mark_run_failed,
+    mark_run_phase,
+    mark_run_processing,
+)
+from app.domains.transcribe.schemas import TranscribeSegment
+from app.domains.transcribe.services import deepgram, transcript_correction
+from app.domains.transcribe.services.deepgram import CONTENT_TYPE_MAP
+
+router = APIRouter(prefix="/transcribe", tags=["transcribe"])
+MAX_FILE_SIZE = 100 * 1024 * 1024
+logger = logging.getLogger(__name__)
+AUDIO_FILE_DESCRIPTION = (
+    "회의 녹음 파일. 지원 포맷: wav/mp3/m4a/aac/flac/ogg/webm, 최대 100MB."
+)
+SPRING_ASYNC_GUIDE = (
+    "Spring 연동 가이드:\n"
+    "1) POST /api/transcribe/decisions/runs 호출로 run_id를 발급받습니다.\n"
+    "2) GET /api/transcribe/decisions/runs/{run_id}를 "
+    "2~5초 간격으로 폴링합니다.\n"
+    "3) phase=transcript_ready 시 transcript_segments를 "
+    "회의 요약 화면에 먼저 반영할 수 있습니다.\n"
+    "4) phase=summary_ready 시 overall_analysis를 반영해 "
+    "요약 화면을 고도화할 수 있습니다.\n"
+    "5) status=completed && phase=decisions_ready 시 "
+    "decision_cards 포함 최종 결과를 저장/전파합니다.\n"
+    "6) status=failed 시 error를 기록하고 필요 시 재시도를 수행합니다.\n"
+    "7) run 조회 404는 만료/정리/재기동 유실 가능성이 있으므로 "
+    "재요청 정책을 둡니다."
+)
+SPRING_DECISION_FAQ = (
+    "팀 공유 FAQ:\n"
+    "- timeline.speaker_id는 null일 수 있습니다. "
+    "짧은 응답어/모호 발화에서 오탐을 피하기 위한 설계입니다.\n"
+    "- summary_ready 단계의 final_decisions_list는 임시값일 수 있으며, "
+    "completed에서 최종 동기화됩니다.\n"
+    "- 재추출이 필요하면 /api/decisions/extract에 "
+    "저장된 transcript_segments를 전달하세요."
+)
+
+
+def _resolve_content_type(audio: UploadFile) -> str:
+    # 파일 확장자/업로드 content-type을 기반으로 MIME 타입 결정
+    ext = Path(audio.filename or "").suffix.lower().lstrip(".")
+    return CONTENT_TYPE_MAP.get(ext, audio.content_type or "application/octet-stream")
+
+
+async def _read_audio_bytes(audio: UploadFile) -> bytes:
+    # 업로드 파일을 바이트로 읽고 최대 크기 제한을 검증
+    audio_bytes = await audio.read()
+    if len(audio_bytes) > MAX_FILE_SIZE:
+        raise HTTPException(status_code=413, detail="파일 크기가 100MB를 초과합니다.")
+    return audio_bytes
+
+
+async def _transcribe_and_correct_from_bytes(
+    audio_bytes: bytes,
+    content_type: str,
+    num_speakers: int | None,
+) -> list[TranscribeSegment]:
+    # 1단계: Deepgram STT + 화자 분리
+    segments = await deepgram.transcribe(audio_bytes, content_type, num_speakers)
+
+    # 2단계: Gemini LLM으로 화자 오인식·짧은 발화 등 후처리
+    return await transcript_correction.correct_transcript(segments, num_speakers)
+
+
+async def _transcribe_and_correct(
+    audio: UploadFile,
+    num_speakers: int | None,
+) -> list[TranscribeSegment]:
+    # 업로드 파일을 읽어 STT + 후처리 파이프라인을 실행
+    content_type = _resolve_content_type(audio)
+    audio_bytes = await _read_audio_bytes(audio)
+    return await _transcribe_and_correct_from_bytes(
+        audio_bytes=audio_bytes,
+        content_type=content_type,
+        num_speakers=num_speakers,
+    )
+
+
+async def _run_transcribe_decision_run(
+    run_id: str,
+    audio_bytes: bytes,
+    content_type: str,
+    num_speakers: int | None,
+    meeting_id: str | None,
+    project_id: str | None,
+) -> None:
+    # 비동기 run의 전체 파이프라인을 단계별(phase)로 실행
+    try:
+        await mark_run_processing(run_id)
+        transcript_segments = await _transcribe_and_correct_from_bytes(
+            audio_bytes=audio_bytes,
+            content_type=content_type,
+            num_speakers=num_speakers,
+        )
+        partial_result = TranscribeDecisionResponse(
+            meeting_id=meeting_id,
+            project_id=project_id,
+            transcript_segments=transcript_segments,
+            decision_result=DecisionExtractionResult(),
+        )
+        await mark_run_phase(
+            run_id=run_id,
+            phase="transcript_ready",
+            result=partial_result,
+        )
+
+        overall_analysis = await extract_overall_analysis(transcript_segments)
+        partial_result.decision_result.overall_analysis = overall_analysis
+        await mark_run_phase(
+            run_id=run_id,
+            phase="summary_ready",
+            result=partial_result,
+        )
+
+        cards_result = await extract_decision_cards_only(transcript_segments)
+        partial_result.decision_result = build_decision_result(
+            overall_analysis=partial_result.decision_result.overall_analysis,
+            cards_result=cards_result,
+        )
+
+        await mark_run_completed(
+            run_id=run_id,
+            result=partial_result,
+        )
+    except AppServiceError as e:
+        await mark_run_failed(run_id, f"{e.status_code}: {e.message}")
+    except Exception as e:
+        logger.exception(
+            "transcribe/decisions run failed",
+            extra={"run_id": run_id},
+        )
+        await mark_run_failed(run_id, f"unexpected_error: {e}")
+
+
+# POST /api/transcribe — 오디오 파일을 받아 화자별 전사 결과 반환
+@router.post(
+    "",
+    response_model=ApiResponse[list[TranscribeSegment]],
+    summary="회의 음성 전사(STT) + 후처리",
+    description=(
+        "오디오 파일을 업로드하면 Deepgram STT와 Gemini 후처리를 거쳐 "
+        "화자 분리 전사 세그먼트를 반환합니다.\n\n"
+        "Spring 가이드: 이 엔드포인트는 전사 결과만 필요할 때 사용합니다. "
+        "결정사항까지 필요하면 /api/transcribe/decisions(동기) 또는 "
+        "/api/transcribe/decisions/runs(비동기)를 사용하세요."
+    ),
+    responses={
+        413: {
+            "model": ApiErrorResponse,
+            "description": "파일 크기가 100MB를 초과했습니다.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "isSuccess": False,
+                        "code": "COMMON_413",
+                        "message": "파일 크기가 100MB를 초과합니다.",
+                        "result": None,
+                    }
+                }
+            },
+        },
+        422: {
+            "model": ApiErrorResponse,
+            "description": "요청 검증 실패(예: num_speakers 범위 오류).",
+        },
+        500: {
+            "model": ApiErrorResponse,
+            "description": "서버 설정 오류(예: API 키 누락).",
+        },
+        502: {
+            "model": ApiErrorResponse,
+            "description": "외부 AI API 연결/응답 오류.",
+        },
+        504: {
+            "model": ApiErrorResponse,
+            "description": "외부 STT API 타임아웃.",
+        },
+    },
+)
+async def transcribe_audio(
+    audio: Annotated[UploadFile, File(description=AUDIO_FILE_DESCRIPTION)],
+    # 화자 수를 알고 있으면 전달 (정확도 향상, 선택사항) — 1~20 범위만 허용
+    num_speakers: int | None = Form(
+        default=None,
+        ge=1,
+        le=20,
+        description="화자 수 힌트(선택). 전달 시 화자 분리 정확도 개선에 도움.",
+    ),
+) -> ApiResponse[list[TranscribeSegment]]:
+    # 전사+후처리 결과만 필요한 경우 사용하는 엔드포인트
+    segments = await _transcribe_and_correct(audio, num_speakers)
+    return ok_response(
+        segments,
+        code="TRANSCRIBE_200",
+        message="전사 및 후처리가 완료되었습니다.",
+    )
+
+
+@router.post(
+    "/decisions",
+    response_model=ApiResponse[TranscribeDecisionResponse],
+    summary="전사 + 후처리 + 의사결정 추출(동기)",
+    description=(
+        "오디오 업로드 후 STT, 후처리, 의사결정 추출을 한 번에 완료해 "
+        "최종 결과를 동기 응답으로 반환합니다.\n\n"
+        "Spring 가이드: 긴 회의에서는 타임아웃 위험이 크므로 "
+        "운영 환경에서는 /api/transcribe/decisions/runs 비동기 방식을 권장합니다."
+    ),
+    responses={
+        413: {
+            "model": ApiErrorResponse,
+            "description": "파일 크기가 100MB를 초과했습니다.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "isSuccess": False,
+                        "code": "COMMON_413",
+                        "message": "파일 크기가 100MB를 초과합니다.",
+                        "result": None,
+                    }
+                }
+            },
+        },
+        422: {
+            "model": ApiErrorResponse,
+            "description": "요청 검증 실패(예: num_speakers 범위 오류).",
+        },
+        500: {
+            "model": ApiErrorResponse,
+            "description": "서버 설정 오류(예: API 키 누락).",
+        },
+        502: {
+            "model": ApiErrorResponse,
+            "description": "외부 AI API 연결/응답 오류 또는 JSON 파싱 오류.",
+        },
+        504: {
+            "model": ApiErrorResponse,
+            "description": "외부 STT API 타임아웃.",
+        },
+    },
+)
+async def transcribe_and_extract_decisions(
+    audio: Annotated[UploadFile, File(description=AUDIO_FILE_DESCRIPTION)],
+    num_speakers: int | None = Form(
+        default=None,
+        ge=1,
+        le=20,
+        description="화자 수 힌트(선택).",
+    ),
+    meeting_id: str | None = Form(
+        default=None,
+        description="호출 측이 관리하는 회의 ID(선택).",
+    ),
+    project_id: str | None = Form(
+        default=None,
+        description="호출 측이 관리하는 프로젝트 ID(선택).",
+    ),
+) -> ApiResponse[TranscribeDecisionResponse]:
+    # 전사부터 의사결정 추출까지 동기로 한 번에 수행
+    transcript_segments = await _transcribe_and_correct(audio, num_speakers)
+    decision_result = await extract_decisions(transcript_segments)
+
+    return ok_response(
+        TranscribeDecisionResponse(
+            meeting_id=meeting_id,
+            project_id=project_id,
+            transcript_segments=transcript_segments,
+            decision_result=decision_result,
+        ),
+        code="TRANSCRIBE_200",
+        message="전사, 후처리, 의사결정 추출이 완료되었습니다.",
+    )
+
+
+@router.post(
+    "/decisions/runs",
+    response_model=ApiResponse[TranscribeDecisionRunAccepted],
+    status_code=202,
+    summary="전사 + 의사결정 추출 비동기 실행 생성",
+    description=(
+        "장시간 작업을 백그라운드로 실행합니다. "
+        "즉시 run_id를 반환하며, 상태는 "
+        "GET /api/transcribe/decisions/runs/{run_id}로 조회합니다.\n\n"
+        f"{SPRING_ASYNC_GUIDE}"
+    ),
+    responses={
+        202: {
+            "description": "비동기 작업이 접수되었습니다.",
+        },
+        413: {
+            "model": ApiErrorResponse,
+            "description": "파일 크기가 100MB를 초과했습니다.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "isSuccess": False,
+                        "code": "COMMON_413",
+                        "message": "파일 크기가 100MB를 초과합니다.",
+                        "result": None,
+                    }
+                }
+            },
+        },
+        422: {
+            "model": ApiErrorResponse,
+            "description": "요청 검증 실패(예: num_speakers 범위 오류).",
+        },
+    },
+)
+async def create_transcribe_decision_run(
+    background_tasks: BackgroundTasks,
+    audio: Annotated[UploadFile, File(description=AUDIO_FILE_DESCRIPTION)],
+    num_speakers: int | None = Form(
+        default=None,
+        ge=1,
+        le=20,
+        description="화자 수 힌트(선택).",
+    ),
+    meeting_id: str | None = Form(
+        default=None,
+        description="호출 측이 관리하는 회의 ID(선택).",
+    ),
+    project_id: str | None = Form(
+        default=None,
+        description="호출 측이 관리하는 프로젝트 ID(선택).",
+    ),
+) -> ApiResponse[TranscribeDecisionRunAccepted]:
+    # 장시간 처리를 백그라운드 run으로 접수하고 run_id를 반환
+    content_type = _resolve_content_type(audio)
+    audio_bytes = await _read_audio_bytes(audio)
+    accepted = await create_run(meeting_id=meeting_id, project_id=project_id)
+    background_tasks.add_task(
+        _run_transcribe_decision_run,
+        accepted.run_id,
+        audio_bytes,
+        content_type,
+        num_speakers,
+        meeting_id=meeting_id,
+        project_id=project_id,
+    )
+    return ok_response(
+        accepted,
+        code="TRANSCRIBE_202",
+        message="비동기 실행이 접수되었습니다.",
+    )
+
+
+@router.get(
+    "/decisions/runs/{run_id}",
+    response_model=ApiResponse[TranscribeDecisionRunStatus],
+    summary="비동기 실행 상태/중간결과 조회",
+    description=(
+        "run_id 기준으로 상태를 조회합니다. "
+        "phase 값은 queued/transcribing/transcript_ready/"
+        "summary_ready/decisions_ready/failed 중 하나입니다.\n\n"
+        "Spring 처리 규칙:\n"
+        "- phase=transcript_ready: transcript_segments 사용 가능(요약 화면 1차 반영)\n"
+        "- phase=summary_ready: decision_result.overall_analysis까지 사용 가능\n"
+        "  (주의: final_decisions_list는 completed 시점에 재동기화되어 바뀔 수 있음)\n"
+        "- status=completed, phase=decisions_ready: decision_cards 포함 최종 반영\n"
+        "- status=failed: error 기준으로 재시도/장애 처리\n\n"
+        f"{SPRING_DECISION_FAQ}"
+    ),
+    responses={
+        200: {
+            "description": "현재 실행 상태 또는 중간/최종 결과.",
+        },
+        404: {
+            "model": ApiErrorResponse,
+            "description": "해당 run_id를 찾을 수 없습니다(만료/정리 포함).",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "isSuccess": False,
+                        "code": "COMMON_404",
+                        "message": "해당 실행을 찾을 수 없습니다.",
+                        "result": None,
+                    }
+                }
+            },
+        },
+    },
+)
+async def get_transcribe_decision_run(
+    run_id: str,
+) -> ApiResponse[TranscribeDecisionRunStatus]:
+    # run_id 기준으로 비동기 실행 상태/중간결과/최종결과 조회
+    status = await get_run_status(run_id)
+    if not status:
+        raise HTTPException(status_code=404, detail="해당 실행을 찾을 수 없습니다.")
+    return ok_response(
+        status,
+        code="TRANSCRIBE_200",
+        message="비동기 실행 상태 조회에 성공했습니다.",
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,107 @@
+import logging
+
+from dotenv import load_dotenv
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from app.api.router import api_router
+from app.core.config import settings
+from app.core.errors import AppServiceError
+from app.core.responses import error_response
+
+# .env 파일의 환경변수 로드 (DEEPGRAM_API_KEY 등)
+load_dotenv()
+
+app = FastAPI(title=settings.app_name, version=settings.app_version)
+app.include_router(api_router)
+logger = logging.getLogger(__name__)
+
+
+def _status_to_error_code(status_code: int) -> str:
+    # HTTP 상태 코드를 서비스 공통 에러 코드로 매핑
+    mapping = {
+        400: "COMMON_400",
+        401: "COMMON_401",
+        403: "COMMON_403",
+        404: "COMMON_404",
+        413: "COMMON_413",
+        422: "COMMON_422",
+        429: "COMMON_429",
+        500: "COMMON_500",
+        502: "COMMON_502",
+        504: "COMMON_504",
+    }
+    return mapping.get(status_code, f"COMMON_{status_code}")
+
+
+@app.exception_handler(AppServiceError)
+async def handle_app_service_error(
+    request: Request, exc: AppServiceError
+) -> JSONResponse:
+    # 서비스 레이어 예외를 공통 에러 응답으로 변환
+    _ = request
+    code = _status_to_error_code(exc.status_code)
+    payload = error_response(
+        code=code,
+        message=exc.message,
+    )
+    return JSONResponse(status_code=exc.status_code, content=payload.model_dump())
+
+
+@app.exception_handler(RequestValidationError)
+async def handle_validation_error(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    # 요청 바디/파라미터 검증 실패 응답 처리
+    _ = request
+    payload = error_response(
+        code="COMMON_422",
+        message="요청 본문 또는 파라미터 검증에 실패했습니다.",
+        result=exc.errors(),
+    )
+    return JSONResponse(status_code=422, content=payload.model_dump())
+
+
+@app.exception_handler(HTTPException)
+async def handle_http_exception(request: Request, exc: HTTPException) -> JSONResponse:
+    # 라우터에서 발생한 HTTP 예외를 공통 포맷으로 변환
+    _ = request
+    code = _status_to_error_code(exc.status_code)
+    detail = exc.detail
+    message = detail if isinstance(detail, str) else "요청 처리 중 오류가 발생했습니다."
+    payload = error_response(
+        code=code,
+        message=message,
+        result=None if isinstance(detail, str) else detail,
+    )
+    return JSONResponse(status_code=exc.status_code, content=payload.model_dump())
+
+
+@app.exception_handler(StarletteHTTPException)
+async def handle_starlette_http_exception(
+    request: Request, exc: StarletteHTTPException
+) -> JSONResponse:
+    # 미등록 경로(404) 등 Starlette 예외를 공통 포맷으로 변환
+    _ = request
+    code = _status_to_error_code(exc.status_code)
+    detail = exc.detail
+    message = detail if isinstance(detail, str) else "요청 처리 중 오류가 발생했습니다."
+    payload = error_response(
+        code=code,
+        message=message,
+        result=None if isinstance(detail, str) else detail,
+    )
+    return JSONResponse(status_code=exc.status_code, content=payload.model_dump())
+
+
+@app.exception_handler(Exception)
+async def handle_unexpected_exception(request: Request, exc: Exception) -> JSONResponse:
+    # 예상하지 못한 예외를 500 공통 응답으로 변환
+    logger.exception("Unhandled exception", extra={"path": str(request.url.path)})
+    payload = error_response(
+        code="COMMON_500",
+        message="서버 내부 오류가 발생했습니다.",
+    )
+    return JSONResponse(status_code=500, content=payload.model_dump())

--- a/main.py
+++ b/main.py
@@ -1,24 +1,3 @@
-from dotenv import load_dotenv
-from fastapi import FastAPI
+from app.main import app as _app
 
-from routers import transcribe
-
-# .env 파일의 환경변수 로드 (DEEPGRAM_API_KEY 등)
-load_dotenv()
-
-app = FastAPI(title="WhyLog FastAPI", version="1.0.0")
-
-# 라우터 등록 — 각 도메인별 엔드포인트를 여기서 연결
-app.include_router(transcribe.router)
-
-
-# 서버 동작 확인용
-@app.get("/")
-def read_root() -> dict[str, str]:
-    return {"message": "FastAPI server is running"}
-
-
-# 헬스체크 — 서버가 살아있는지 확인 (배포 환경에서 주로 사용)
-@app.get("/health")
-def health_check() -> dict[str, str]:
-    return {"status": "ok"}
+app = _app

--- a/routers/decision.py
+++ b/routers/decision.py
@@ -1,0 +1,3 @@
+from app.domains.decision.router import router
+
+__all__ = ["router"]

--- a/routers/transcribe.py
+++ b/routers/transcribe.py
@@ -1,35 +1,3 @@
-from pathlib import Path
+from app.domains.transcribe.router import router
 
-from fastapi import APIRouter, Form, HTTPException, UploadFile
-
-from schemas.transcribe import TranscribeSegment
-from services import deepgram, transcript_correction
-from services.deepgram import CONTENT_TYPE_MAP
-
-router = APIRouter(prefix="/api", tags=["transcribe"])
-
-
-# POST /api/transcribe — 오디오 파일을 받아 화자별 전사 결과 반환
-@router.post("/transcribe")
-async def transcribe_audio(
-    audio: UploadFile,
-    # 화자 수를 알고 있으면 전달 (정확도 향상, 선택사항) — 1~20 범위만 허용
-    num_speakers: int | None = Form(default=None, ge=1, le=20),
-) -> list[TranscribeSegment]:
-    # 확장자로 MIME 타입 결정 (없으면 파일 자체의 content_type 사용)
-    ext = Path(audio.filename or "").suffix.lower().lstrip(".")
-    content_type = CONTENT_TYPE_MAP.get(
-        ext, audio.content_type or "application/octet-stream"
-    )
-
-    # 대용량 파일 메모리 보호 (500MB 초과 차단)
-    MAX_FILE_SIZE = 500 * 1024 * 1024
-    audio_bytes = await audio.read()
-    if len(audio_bytes) > MAX_FILE_SIZE:
-        raise HTTPException(status_code=413, detail="파일 크기가 500MB를 초과합니다.")
-
-    # 1단계: Deepgram STT + 화자 분리
-    segments = await deepgram.transcribe(audio_bytes, content_type, num_speakers)
-
-    # 2단계: Gemini LLM으로 화자 오인식·짧은 발화 등 후처리
-    return await transcript_correction.correct_transcript(segments, num_speakers)
+__all__ = ["router"]

--- a/schemas/decision.py
+++ b/schemas/decision.py
@@ -1,0 +1,19 @@
+from app.domains.decision.schemas import (
+    DecisionCard,
+    DecisionExtractionResult,
+    DecisionExtractRequest,
+    DecisionExtractResponse,
+    DecisionTimelineItem,
+    MeetingInfo,
+    OverallAnalysis,
+)
+
+__all__ = [
+    "DecisionCard",
+    "DecisionExtractRequest",
+    "DecisionExtractResponse",
+    "DecisionExtractionResult",
+    "DecisionTimelineItem",
+    "MeetingInfo",
+    "OverallAnalysis",
+]

--- a/services/decision_extraction.py
+++ b/services/decision_extraction.py
@@ -1,0 +1,7 @@
+from app.domains.decision.services.extraction import (
+    DECISION_POLICY_PROMPT,
+    GEMINI_MODEL,
+    extract_decisions,
+)
+
+__all__ = ["DECISION_POLICY_PROMPT", "GEMINI_MODEL", "extract_decisions"]


### PR DESCRIPTION
<!-- PR 제목 예시 -> [feat/#3] Deepgram 음성 전사 API 구현 -->

## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->
후처리된 STT를 기반으로 의사결정 추출 파이프라인을 연동했습니다.  
동기/비동기 실행 경로를 모두 제공하고, 비동기에서는 phase 기반 polling으로 중간 결과부터 최종 결과까지 조회할 수 있습니다.

## 📄 작업 내용
- `POST /api/transcribe/decisions` 동기 파이프라인 구현 (STT 후처리 + 의사결정 추출)
- `POST /api/transcribe/decisions/runs` 비동기 실행 생성(run_id 발급)
- `GET /api/transcribe/decisions/runs/{run_id}` 상태/중간결과/최종결과 polling 구현
- `POST /api/decisions/extract` 저장된 transcript 기반 재추출 API 구현
- run 상태 전이 관리: `queued -> transcribing -> transcript_ready -> summary_ready -> decisions_ready/failed`
- 동기/비동기 결과 조립 로직 일원화
- timeline `speaker_id` 보정 로직 및 nullable 정책 적용
- Swagger에 Spring 연동 가이드(phase 처리, polling, 운영 주의사항) 반영

## 📌 관련 이슈
- close #3 
- close #5 
- refs #4

## 🔌 API 변경사항 (해당 시)
<!-- 새로운 엔드포인트 추가 또는 기존 변경이 있다면 적어주세요. -->
- 추가/변경 엔드포인트
  - `POST /api/transcribe/decisions`
  - `POST /api/transcribe/decisions/runs`
  - `GET /api/transcribe/decisions/runs/{run_id}`
  - `POST /api/decisions/extract`
- 비동기 phase enum
  - `queued`, `transcribing`, `transcript_ready`, `summary_ready`, `decisions_ready`, `failed`
- `DecisionTimelineItem.speaker_id` 타입
  - `string | null`
- 공통 응답 DTO 포맷 사용
  - 성공: `{ "isSuccess": true, "code": "TRANSCRIBE_200|202 / DECISION_200", "message": "...", "result": ... }`
  - 실패: `{ "isSuccess": false, "code": "COMMON_xxx", "message": "...", "result": ... }`
## 💬 기타 사항
<!-- 리뷰어가 알면 좋을 내용이 있다면 적어주세요 -->
- `summary_ready` 단계의 `final_decisions_list`는 중간값일 수 있으며, `decisions_ready` 완료 시점에 최종 동기화됩니다.
- `speaker_id`가 `null`인 경우는 오탐 방지를 위한 의도된 정책입니다.
- 검증 결과는 노션에 넣어두었습니다. 다양한 음성파일로 테스트 해보며 개선해야할 것 같습니다..