### PR TITLE
[feat/#15] 커밋 임베딩 ChromaDB 저장 연동

### DIFF
--- a/app/core/chroma.py
+++ b/app/core/chroma.py
@@ -13,6 +13,15 @@ def get_chroma_client() -> chromadb.ClientAPI:
     return _client
 
 
+def get_commit_collection() -> chromadb.Collection:
+    """커밋 임베딩 컬렉션을 반환한다 (없으면 자동 생성)."""
+    client = get_chroma_client()
+    return client.get_or_create_collection(
+        name=settings.commit_collection,
+        metadata={"hnsw:space": "cosine"},
+    )
+
+
 def get_decision_collection() -> chromadb.Collection:
     """결정사항 임베딩 컬렉션을 반환한다 (없으면 자동 생성)."""
     client = get_chroma_client()

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -20,6 +20,11 @@ class AppSettings(BaseModel):
         default_factory=lambda: os.getenv("CHROMA_PERSIST_DIR", "./chroma_data")
     )
 
+    # Commit Embedding
+    commit_collection: str = Field(
+        default_factory=lambda: os.getenv("COMMIT_COLLECTION", "commit_embeddings")
+    )
+
     # Decision Embedding
     decision_embedding_model: str = Field(
         default_factory=lambda: os.getenv(

--- a/app/domains/commit/router.py
+++ b/app/domains/commit/router.py
@@ -18,8 +18,14 @@ router = APIRouter(prefix="/commit", tags=["commit"])
     response_model=ApiResponse[CommitAnalyzeResponse],
     summary="커밋 분석 API",
     description="Spring에서 커밋 메시지와 diff를 받아 "
-    "LLM으로 요약한 결과를 반환합니다. "
-    "임베딩용 상세 텍스트는 백그라운드에서 생성됩니다.",
+    "LLM(Gemini)으로 요약한 결과를 반환합니다.\n\n"
+    "**백그라운드 임베딩 저장:**\n"
+    "- 구조화 임베딩 텍스트 생성 → Gemini Embedding API 벡터 변환 → "
+    "ChromaDB(commit_embeddings) 저장\n"
+    "- 동일 commit_id 재호출 시 기존 데이터를 덮어씁니다 (upsert)\n"
+    "- 문서 ID: commit_{commit_id}\n"
+    "- 임베딩 텍스트: title: {repo} {subject} | text: "
+    "변경요약: | 기술키워드: | 변경방향: | 파일맥락: ",
     responses={
         400: {
             "model": ApiErrorResponse,

--- a/app/domains/commit/services/summarize.py
+++ b/app/domains/commit/services/summarize.py
@@ -150,20 +150,39 @@ async def _call_gemini(
     raise last_error  # type: ignore[misc]
 
 
-async def _generate_embedding(text: str) -> list[float]:
+async def _generate_embedding(text: str, timeout: float = 30.0) -> list[float]:
     """Gemini Embedding API로 단일 텍스트의 임베딩 벡터를 생성한다."""
     client = _get_client()
-    try:
-        response = await client.aio.models.embed_content(
-            model=settings.decision_embedding_model,
-            contents=text,
-        )
-    except Exception as e:
-        raise AppServiceError(
-            f"Gemini 임베딩 생성 실패: {e}",
-            status_code=502,
-        ) from e
-    return response.embeddings[0].values
+    last_error: Exception | None = None
+    for attempt in range(len(RETRY_BACKOFFS) + 1):
+        try:
+            response = await asyncio.wait_for(
+                client.aio.models.embed_content(
+                    model=settings.decision_embedding_model,
+                    contents=text,
+                ),
+                timeout=timeout,
+            )
+            if not response.embeddings:
+                raise ValueError("Gemini 임베딩 응답이 비어 있습니다.")
+            return response.embeddings[0].values
+        except genai_errors.APIError as e:
+            if e.code not in RETRY_STATUS_CODES or attempt >= len(RETRY_BACKOFFS):
+                raise AppServiceError(
+                    f"Gemini 임베딩 생성 실패: {e}",
+                    status_code=502,
+                ) from e
+            backoff = RETRY_BACKOFFS[attempt]
+            logger.warning(
+                "Gemini 임베딩 %s 응답, %.1f초 후 재시도 (%d/%d)",
+                e.code,
+                backoff,
+                attempt + 1,
+                len(RETRY_BACKOFFS),
+            )
+            last_error = e
+            await asyncio.sleep(backoff)
+    raise last_error  # type: ignore[misc]
 
 
 async def summarize_commit(

--- a/app/domains/commit/services/summarize.py
+++ b/app/domains/commit/services/summarize.py
@@ -96,7 +96,7 @@ def _parse_embedding_response(text: str) -> ParsedEmbedding:
     return ParsedEmbedding(
         summary=summary,
         tech_keywords=tech_keywords,
-        directions=directions or ["modify"],
+        directions=directions,
         module_tags=module_tags,
     )
 
@@ -203,7 +203,8 @@ async def generate_embedding_text(
         text_parts = [f"변경요약: {parsed.summary}"]
         if parsed.tech_keywords:
             text_parts.append(f"기술키워드: {','.join(parsed.tech_keywords)}")
-        text_parts.append(f"변경방향: {','.join(parsed.directions)}")
+        if parsed.directions:
+            text_parts.append(f"변경방향: {','.join(parsed.directions)}")
         if parsed.module_tags:
             text_parts.append(f"파일맥락: {','.join(parsed.module_tags)}")
         embedding_text = f"title: {title} | text: {' | '.join(text_parts)}"

--- a/app/domains/commit/services/summarize.py
+++ b/app/domains/commit/services/summarize.py
@@ -6,6 +6,7 @@ from google import genai
 from google.genai import errors as genai_errors
 from google.genai import types
 
+from app.core.chroma import get_commit_collection
 from app.core.config import settings
 from app.core.errors import AppServiceError
 from app.domains.commit.schemas import ChangedFile
@@ -149,6 +150,22 @@ async def _call_gemini(
     raise last_error  # type: ignore[misc]
 
 
+async def _generate_embedding(text: str) -> list[float]:
+    """Gemini Embedding API로 단일 텍스트의 임베딩 벡터를 생성한다."""
+    client = _get_client()
+    try:
+        response = await client.aio.models.embed_content(
+            model=settings.decision_embedding_model,
+            contents=text,
+        )
+    except Exception as e:
+        raise AppServiceError(
+            f"Gemini 임베딩 생성 실패: {e}",
+            status_code=502,
+        ) from e
+    return response.embeddings[0].values
+
+
 async def summarize_commit(
     message: str,
     changed_file_list: list[ChangedFile],
@@ -209,7 +226,26 @@ async def generate_embedding_text(
             text_parts.append(f"파일맥락: {','.join(parsed.module_tags)}")
         embedding_text = f"title: {title} | text: {' | '.join(text_parts)}"
 
-        # TODO: ChromaDB에 commit_id + embedding_text 저장
-        logger.info("커밋 %d 임베딩 텍스트 생성 완료: %s", commit_id, embedding_text)
+        # 3) 임베딩 벡터 생성
+        embedding = await _generate_embedding(embedding_text)
+
+        # 4) ChromaDB 저장
+        collection = get_commit_collection()
+        doc_id = f"commit_{commit_id}"
+        metadata = {
+            "commit_id": commit_id,
+            "repository": repository,
+            "direction": ",".join(parsed.directions),
+            "tech_keywords_csv": ",".join(parsed.tech_keywords),
+            "module_tags_csv": ",".join(parsed.module_tags),
+        }
+        await asyncio.to_thread(
+            collection.upsert,
+            ids=[doc_id],
+            documents=[embedding_text],
+            embeddings=[embedding],
+            metadatas=[metadata],
+        )
+        logger.info("커밋 %d 임베딩 저장 완료: %s", commit_id, doc_id)
     except Exception:
         logger.exception("커밋 %d 임베딩 텍스트 생성 실패", commit_id)


### PR DESCRIPTION
<!-- PR 제목 예시 -> [feat/#3] Deepgram 음성 전사 API 구현 -->

## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->
커밋 임베딩을 Gemini Embedding API로 벡터 변환 후 ChromaDB에 저장하는 파이프라인을 연동하고, direction 파싱 실패 시 폴백 로직을 수정했습니다.

## 📄 작업 내용
- ChromaDB 커밋 임베딩 컬렉션 설정 추가 (config.py, chroma.py)
- Gemini Embedding API로 벡터 생성 후 ChromaDB에 upsert 저장 구현
- 신뢰도 점수 계산에 필요한 metadata 함께 저장 (commit_id, repository, direction, tech_keywords_csv, module_tags_csv)
- direction 파싱 실패 시 `modify` 폴백 제거 → 빈 리스트로 처리 (신뢰도 점수 왜곡 방지)

## 📌 관련 이슈
- close #15 

## 🔌 API 변경사항 (해당 시)
<!-- 새로운 엔드포인트 추가 또는 기존 변경이 있다면 적어주세요. -->
`POST /api/commit/analyze` — 기존 응답은 동일, 백그라운드에서 ChromaDB 임베딩 저장이 추가됨

## 💬 기타 사항
<!-- 리뷰어가 알면 좋을 내용이 있다면 적어주세요 -->
decision 쪽과 달리 커밋 임베딩은 백그라운드에서 저장되기 때문에 스웨거 응답에서 ChromaDB 데이터를 확인할 수 없어 아래 명령어로 확인 가능하니 참고부탁드립니다!

```
python -c "
import chromadb
c = chromadb.PersistentClient(path='./chroma_data')
col = c.get_collection('commit_embeddings')
result = col.get(include=['documents', 'metadatas'])
print('IDs:', result['ids'])
print('Documents:', result['documents'])
print('Metadatas:', result['metadatas'])
"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 커밋 임베딩을 지정된 컬렉션에 영구 저장(중복시 upsert)하여 향후 조회/검색에 활용 가능

* **문서화**
  * API 설명에 LLM(Gemini) 명시 및 임베딩 생성·저장 워크플로우 상세화

* **버그 수정 / 개선**
  * 임베딩 생성 실패 시 적절한 오류 반환 및 재시도 로직 추가
  * 임베딩 텍스트 구성에서 변경 방향 필드가 없을 경우 생략하도록 수정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->