### PR TITLE
[feat/#14] 결정사항-커밋 유사도 매칭 API 구현

### DIFF
--- a/app/domains/commit/router.py
+++ b/app/domains/commit/router.py
@@ -2,8 +2,14 @@ from fastapi import APIRouter, BackgroundTasks
 
 from app.core.errors import AppServiceError
 from app.core.responses import ApiErrorResponse, ApiResponse, ok_response
-from app.domains.commit.schemas import CommitAnalyzeRequest, CommitAnalyzeResponse
+from app.domains.commit.schemas import (
+    CommitAnalyzeRequest,
+    CommitAnalyzeResponse,
+    DecisionCommitMatchRequest,
+    DecisionCommitMatchResponse,
+)
 from app.domains.commit.services.diff_filter import filter_changed_files
+from app.domains.commit.services.matching import match_decisions_with_commits
 from app.domains.commit.services.summarize import (
     generate_embedding_text,
     summarize_commit,
@@ -23,6 +29,7 @@ router = APIRouter(prefix="/commit", tags=["commit"])
     "- 구조화 임베딩 텍스트 생성 → Gemini Embedding API 벡터 변환 → "
     "ChromaDB(commit_embeddings) 저장\n"
     "- 동일 commit_id 재호출 시 기존 데이터를 덮어씁니다 (upsert)\n"
+    "- commit_hash가 포함되면 매칭 결과 식별용 메타데이터로 함께 저장합니다\n"
     "- 문서 ID: commit_{commit_id}\n"
     "- 임베딩 텍스트: title: {repo} {subject} | text: "
     "변경요약: | 기술키워드: | 변경방향: | 파일맥락: ",
@@ -61,10 +68,51 @@ async def analyze_commit(
     background_tasks.add_task(
         generate_embedding_text,
         request.commit_id,
+        request.commit_hash,
         request.repository,
         request.message,
         filtered_files,
     )
     return ok_response(
         CommitAnalyzeResponse(commit_id=request.commit_id, summary=summary)
+    )
+
+
+@router.post(
+    "/match",
+    response_model=ApiResponse[DecisionCommitMatchResponse],
+    summary="결정사항-커밋 유사도 매칭",
+    description=(
+        "회의 결정사항(applied_item 단위)과 "
+        "커밋 임베딩 후보를 유사도 기반으로 매칭합니다.\n\n"
+        "점수 정책(100점):\n"
+        "- 의미 유사성 50\n"
+        "- 기술 키워드 일치도 30\n"
+        "- 파일/모듈 맥락 일치도 20\n"
+        "- 반대 의미(도입 vs 제거)는 semantic 0 처리\n"
+        "- 추상 커밋/모호한 결정사항은 보정 감점\n\n"
+        "상태 구간:\n"
+        "- 70~100: APPLIED\n"
+        "- 50~69: PARTIAL\n"
+        "- 0~49: 미표시(UNAPPLIED)"
+    ),
+    responses={
+        422: {
+            "model": ApiErrorResponse,
+            "description": "요청 스키마 검증 실패(예: meeting_id 형식, top_k 범위).",
+        },
+        502: {
+            "model": ApiErrorResponse,
+            "description": "ChromaDB 조회 실패.",
+        },
+    },
+)
+async def match_decision_commits(
+    request: DecisionCommitMatchRequest,
+) -> ApiResponse[DecisionCommitMatchResponse]:
+    result = await match_decisions_with_commits(request)
+    return ok_response(
+        result=result,
+        code="COMMIT_MATCH_200",
+        message="결정사항-커밋 매칭 분석이 완료되었습니다.",
     )

--- a/app/domains/commit/router.py
+++ b/app/domains/commit/router.py
@@ -31,7 +31,7 @@ router = APIRouter(prefix="/commit", tags=["commit"])
     "- 동일 commit_id 재호출 시 기존 데이터를 덮어씁니다 (upsert)\n"
     "- commit_hash가 포함되면 매칭 결과 식별용 메타데이터로 함께 저장합니다\n"
     "- 문서 ID: commit_{commit_id}\n"
-    "- 임베딩 텍스트: title: {repo} {subject} | text: "
+    "- 임베딩 텍스트: title: repository-{repository_id} {subject} | text: "
     "변경요약: | 기술키워드: | 변경방향: | 파일맥락: ",
     responses={
         400: {
@@ -69,7 +69,7 @@ async def analyze_commit(
         generate_embedding_text,
         request.commit_id,
         request.commit_hash,
-        request.repository,
+        request.repository_id,
         request.message,
         filtered_files,
     )
@@ -81,20 +81,18 @@ async def analyze_commit(
 @router.post(
     "/match",
     response_model=ApiResponse[DecisionCommitMatchResponse],
-    summary="결정사항-커밋 유사도 매칭",
+    summary="결정사항-커밋 추천 매칭",
     description=(
         "회의 결정사항(applied_item 단위)과 "
-        "커밋 임베딩 후보를 유사도 기반으로 매칭합니다.\n\n"
+        "커밋 임베딩 후보를 유사도 기반으로 추천합니다.\n\n"
         "점수 정책(100점):\n"
         "- 의미 유사성 50\n"
         "- 기술 키워드 일치도 30\n"
         "- 파일/모듈 맥락 일치도 20\n"
         "- 반대 의미(도입 vs 제거)는 semantic 0 처리\n"
         "- 추상 커밋/모호한 결정사항은 보정 감점\n\n"
-        "상태 구간:\n"
-        "- 70~100: APPLIED\n"
-        "- 50~69: PARTIAL\n"
-        "- 0~49: 미표시(UNAPPLIED)"
+        "응답은 결정사항별 추천 커밋을 신뢰도 내림차순으로 반환합니다.\n"
+        "사용자 연결 상태는 Spring 서버에서 별도로 관리합니다."
     ),
     responses={
         422: {
@@ -114,5 +112,5 @@ async def match_decision_commits(
     return ok_response(
         result=result,
         code="COMMIT_MATCH_200",
-        message="결정사항-커밋 매칭 분석이 완료되었습니다.",
+        message="결정사항-커밋 추천 분석이 완료되었습니다.",
     )

--- a/app/domains/commit/schemas.py
+++ b/app/domains/commit/schemas.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 
@@ -8,6 +10,11 @@ class ChangedFile(BaseModel):
 
 class CommitAnalyzeRequest(BaseModel):
     commit_id: int = Field(ge=0, description="커밋 ID")
+    commit_hash: str | None = Field(
+        default=None,
+        pattern=r"^[a-fA-F0-9]{7,64}$",
+        description="Git 커밋 해시",
+    )
     repository: str = Field(min_length=1, description="레포지토리 이름")
     message: str = Field(min_length=1, description="커밋 메시지")
     changed_file_list: list[ChangedFile] = Field(
@@ -18,3 +25,83 @@ class CommitAnalyzeRequest(BaseModel):
 class CommitAnalyzeResponse(BaseModel):
     commit_id: int = Field(description="커밋 ID")
     summary: str = Field(description="커밋 요약")
+
+
+class MatchScoreBreakdown(BaseModel):
+    semantic: int = Field(description="의미 유사성 점수(0~50)")
+    keyword: int = Field(description="기술 키워드 일치도 점수(0~30)")
+    context: int = Field(description="파일/모듈 맥락 점수(0~20)")
+    penalty: int = Field(description="보정 감점 합계(0~20)")
+    total: int = Field(description="최종 신뢰도 점수(0~100)")
+
+
+class DecisionCommitMatchRequest(BaseModel):
+    meeting_id: str = Field(
+        description="결정사항 임베딩을 조회할 회의 ID",
+        pattern=r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$",
+    )
+    project_id: str | None = Field(
+        default=None,
+        description="프로젝트 ID (선택, 커밋 메타데이터 필터 보조)",
+    )
+    repository: str | None = Field(
+        default=None,
+        description="레포지토리 이름 (선택, 미지정 시 전체 후보 조회)",
+    )
+    top_k: int = Field(
+        default=10,
+        ge=1,
+        le=30,
+        description="적용사항별 커밋 후보 상위 K",
+    )
+
+
+class MatchedCommit(BaseModel):
+    commit_id: int | None = Field(default=None, description="커밋 ID")
+    commit_ref: str | None = Field(default=None, description="커밋 참조 ID")
+    commit_hash: str | None = Field(default=None, description="커밋 해시")
+    repository: str | None = Field(default=None, description="레포지토리")
+    status: Literal["APPLIED", "PARTIAL"] = Field(description="연결 상태")
+    confidence: int = Field(description="신뢰도 점수(0~100)")
+    reason: str = Field(description="연결 사유 요약")
+    score_breakdown: MatchScoreBreakdown = Field(description="점수 구성 상세")
+    direction_primary: str | None = Field(default=None, description="대표 변경 방향")
+    direction_multi: list[str] = Field(
+        default_factory=list, description="다중 변경 방향 목록"
+    )
+    tech_keywords: list[str] = Field(
+        default_factory=list, description="커밋 기술 키워드 목록"
+    )
+    module_tags: list[str] = Field(default_factory=list, description="모듈/경로 태그")
+
+
+class DecisionCommitMatchItem(BaseModel):
+    decision_document_id: str = Field(description="결정사항 문서 ID")
+    decision_title: str = Field(description="결정사항 제목")
+    applied_item: str = Field(description="적용사항")
+    decision_status: Literal["APPLIED", "PARTIAL", "UNAPPLIED"] = Field(
+        description="적용 상태"
+    )
+    connected_commits: list[MatchedCommit] = Field(
+        default_factory=list,
+        description="강한 연결(APPLIED) 커밋 목록",
+    )
+    recommended_commits: list[MatchedCommit] = Field(
+        default_factory=list,
+        description="약한 연결(PARTIAL) 추천 커밋 목록",
+    )
+
+
+class DecisionCommitMatchResponse(BaseModel):
+    meeting_id: str = Field(description="회의 ID")
+    project_id: str | None = Field(default=None, description="프로젝트 ID")
+    repository: str | None = Field(default=None, description="레포지토리 필터")
+    total_decision_items: int = Field(description="조회된 적용사항 문서 수")
+    matched_decision_items: int = Field(description="연결 결과가 존재하는 문서 수")
+    decisions: list[DecisionCommitMatchItem] = Field(
+        default_factory=list, description="적용사항 단위 매칭 결과"
+    )
+    notice: str = Field(
+        default="신뢰도는 AI 분석 기반 추정값입니다.",
+        description="신뢰도 안내 문구",
+    )

--- a/app/domains/commit/schemas.py
+++ b/app/domains/commit/schemas.py
@@ -1,5 +1,3 @@
-from typing import Literal
-
 from pydantic import BaseModel, Field
 
 
@@ -15,7 +13,7 @@ class CommitAnalyzeRequest(BaseModel):
         pattern=r"^[a-fA-F0-9]{7,64}$",
         description="Git 커밋 해시",
     )
-    repository: str = Field(min_length=1, description="레포지토리 이름")
+    repository_id: int = Field(ge=0, description="레포지토리 ID")
     message: str = Field(min_length=1, description="커밋 메시지")
     changed_file_list: list[ChangedFile] = Field(
         min_length=1, description="변경된 파일 목록"
@@ -40,15 +38,16 @@ class DecisionCommitMatchRequest(BaseModel):
         description="결정사항 임베딩을 조회할 회의 ID",
         pattern=r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$",
     )
-    repository: str | None = Field(
+    repository_id: int | None = Field(
         default=None,
-        description="레포지토리 이름 (선택, 미지정 시 전체 후보 조회)",
+        ge=0,
+        description="레포지토리 ID (선택, 미지정 시 전체 후보 조회)",
     )
     top_k: int = Field(
-        default=10,
+        default=5,
         ge=1,
         le=30,
-        description="적용사항별 커밋 후보 상위 K",
+        description="적용사항별 추천 커밋 상위 K",
     )
 
 
@@ -56,10 +55,10 @@ class MatchedCommit(BaseModel):
     commit_id: int | None = Field(default=None, description="커밋 ID")
     commit_ref: str | None = Field(default=None, description="커밋 참조 ID")
     commit_hash: str | None = Field(default=None, description="커밋 해시")
-    repository: str | None = Field(default=None, description="레포지토리")
-    status: Literal["APPLIED", "PARTIAL"] = Field(description="연결 상태")
+    commit_message: str | None = Field(default=None, description="커밋 메시지")
+    repository_id: int | None = Field(default=None, description="레포지토리 ID")
     confidence: int = Field(description="신뢰도 점수(0~100)")
-    reason: str = Field(description="연결 사유 요약")
+    reason: str = Field(description="추천 사유 요약")
     score_breakdown: MatchScoreBreakdown = Field(description="점수 구성 상세")
     direction_primary: str | None = Field(default=None, description="대표 변경 방향")
     direction_multi: list[str] = Field(
@@ -75,24 +74,17 @@ class DecisionCommitMatchItem(BaseModel):
     decision_document_id: str = Field(description="결정사항 문서 ID")
     decision_title: str = Field(description="결정사항 제목")
     applied_item: str = Field(description="적용사항")
-    decision_status: Literal["APPLIED", "PARTIAL", "UNAPPLIED"] = Field(
-        description="적용 상태"
-    )
-    connected_commits: list[MatchedCommit] = Field(
-        default_factory=list,
-        description="강한 연결(APPLIED) 커밋 목록",
-    )
     recommended_commits: list[MatchedCommit] = Field(
         default_factory=list,
-        description="약한 연결(PARTIAL) 추천 커밋 목록",
+        description="신뢰도 내림차순 추천 커밋 목록",
     )
 
 
 class DecisionCommitMatchResponse(BaseModel):
     meeting_id: str = Field(description="회의 ID")
-    repository: str | None = Field(default=None, description="레포지토리 필터")
+    repository_id: int | None = Field(default=None, description="레포지토리 ID 필터")
     total_decision_items: int = Field(description="조회된 적용사항 문서 수")
-    matched_decision_items: int = Field(description="연결 결과가 존재하는 문서 수")
+    matched_decision_items: int = Field(description="추천 결과가 존재하는 문서 수")
     decisions: list[DecisionCommitMatchItem] = Field(
         default_factory=list, description="적용사항 단위 매칭 결과"
     )

--- a/app/domains/commit/schemas.py
+++ b/app/domains/commit/schemas.py
@@ -40,10 +40,6 @@ class DecisionCommitMatchRequest(BaseModel):
         description="결정사항 임베딩을 조회할 회의 ID",
         pattern=r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$",
     )
-    project_id: str | None = Field(
-        default=None,
-        description="프로젝트 ID (선택, 커밋 메타데이터 필터 보조)",
-    )
     repository: str | None = Field(
         default=None,
         description="레포지토리 이름 (선택, 미지정 시 전체 후보 조회)",
@@ -94,7 +90,6 @@ class DecisionCommitMatchItem(BaseModel):
 
 class DecisionCommitMatchResponse(BaseModel):
     meeting_id: str = Field(description="회의 ID")
-    project_id: str | None = Field(default=None, description="프로젝트 ID")
     repository: str | None = Field(default=None, description="레포지토리 필터")
     total_decision_items: int = Field(description="조회된 적용사항 문서 수")
     matched_decision_items: int = Field(description="연결 결과가 존재하는 문서 수")

--- a/app/domains/commit/services/matching.py
+++ b/app/domains/commit/services/matching.py
@@ -14,7 +14,6 @@ from app.domains.commit.schemas import (
 )
 from app.domains.decision.services.matching_scoring import (
     ScoringInput,
-    build_connection_reason,
     calculate_match_score,
     extract_direction_labels_from_text,
     extract_module_tokens,
@@ -66,6 +65,41 @@ def _csv_to_list(value: str | None) -> list[str]:
     if not value:
         return []
     return [token for token in (part.strip() for part in value.split(",")) if token]
+
+
+def _format_tokens(tokens: set[str], *, limit: int = 3) -> str:
+    if not tokens:
+        return "없음"
+    sorted_tokens = sorted(tokens)
+    shown = sorted_tokens[:limit]
+    suffix = (
+        "" if len(sorted_tokens) <= limit else f" 외 {len(sorted_tokens) - limit}개"
+    )
+    return ", ".join(shown) + suffix
+
+
+def _build_recommendation_reason(
+    *,
+    score: Any,
+    decision_keywords: set[str],
+    commit_keywords: set[str],
+    decision_modules: set[str],
+    commit_modules: set[str],
+) -> str:
+    keyword_overlap = decision_keywords & commit_keywords
+    module_overlap = decision_modules & commit_modules
+
+    parts = [
+        (
+            f"총 {score.total}점: 의미 {score.semantic}/50, "
+            f"키워드 {score.keyword}/30, 맥락 {score.context}/20"
+        )
+    ]
+    if score.penalty:
+        parts.append(f"보정 감점 {score.penalty}점")
+    parts.append(f"겹친 키워드: {_format_tokens(keyword_overlap)}")
+    parts.append(f"겹친 모듈: {_format_tokens(module_overlap)}")
+    return ". ".join(parts) + "."
 
 
 def _to_float_list(value: Any) -> list[float] | None:
@@ -196,14 +230,21 @@ async def _query_commit_candidates(
     query_embedding: list[float],
     *,
     n_results: int,
+    repository_id: int | None,
 ) -> dict[str, Any]:
     collection = get_commit_collection()
+    query_kwargs: dict[str, Any] = {
+        "query_embeddings": [query_embedding],
+        "n_results": n_results,
+        "include": ["documents", "metadatas", "distances"],
+    }
+    if repository_id is not None:
+        query_kwargs["where"] = {"repository_id": repository_id}
+
     try:
         return await asyncio.to_thread(
             collection.query,
-            query_embeddings=[query_embedding],
-            n_results=n_results,
-            include=["documents", "metadatas", "distances"],
+            **query_kwargs,
         )
     except Exception as e:
         raise AppServiceError(
@@ -224,7 +265,8 @@ def _build_match_record(
     stored_commit_id = _first_int(metadata.get("commit_id"))
     commit_ref = _first_str(metadata.get("commit_ref"))
     commit_hash = _first_str(metadata.get("commit_hash"))
-    repository = _first_str(metadata.get("repository"))
+    commit_message = _first_str(metadata.get("commit_message")) or commit_document
+    repository_id = _first_int(metadata.get("repository_id"))
 
     direction_primary = _first_str(metadata.get("direction_primary")) or _first_str(
         metadata.get("direction")
@@ -256,9 +298,7 @@ def _build_match_record(
             semantic_distance=_normalize_distance(distance),
             decision_text=decision.text,
             commit_text=commit_document,
-            commit_message=(
-                _first_str(metadata.get("commit_message")) or commit_document
-            ),
+            commit_message=commit_message,
             decision_direction_labels=decision.direction_labels,
             commit_direction_labels=commit_direction_labels,
             decision_keywords=decision.keywords,
@@ -275,10 +315,16 @@ def _build_match_record(
         commit_id=stored_commit_id,
         commit_ref=commit_ref,
         commit_hash=commit_hash,
-        repository=repository,
-        status=score.status,
+        commit_message=commit_message,
+        repository_id=repository_id,
         confidence=score.total,
-        reason=build_connection_reason(score),
+        reason=_build_recommendation_reason(
+            score=score,
+            decision_keywords=decision.keywords,
+            commit_keywords=commit_keywords,
+            decision_modules=decision.modules,
+            commit_modules=commit_modules,
+        ),
         score_breakdown=MatchScoreBreakdown(
             semantic=score.semantic,
             keyword=score.keyword,
@@ -307,7 +353,7 @@ async def match_decisions_with_commits(
     if not decision_entries:
         return DecisionCommitMatchResponse(
             meeting_id=payload.meeting_id,
-            repository=payload.repository,
+            repository_id=payload.repository_id,
             total_decision_items=0,
             matched_decision_items=0,
             decisions=[],
@@ -329,6 +375,7 @@ async def match_decisions_with_commits(
         query_result = await _query_commit_candidates(
             decision.embedding,
             n_results=pool_size,
+            repository_id=payload.repository_id,
         )
 
         ids_nested = query_result.get("ids") or [[]]
@@ -343,9 +390,12 @@ async def match_decisions_with_commits(
 
         for idx, commit_id in enumerate(ids):
             metadata = metadatas[idx] if idx < len(metadatas) and metadatas[idx] else {}
-            commit_repository = _first_str(metadata.get("repository"))
+            commit_repository_id = _first_int(metadata.get("repository_id"))
 
-            if payload.repository and commit_repository != payload.repository:
+            if (
+                payload.repository_id is not None
+                and commit_repository_id != payload.repository_id
+            ):
                 continue
 
             commit_document = docs[idx] if idx < len(docs) and docs[idx] else ""
@@ -391,40 +441,23 @@ async def match_decisions_with_commits(
             reverse=True,
         )[: payload.top_k]
 
-        connected_commits = [
-            record.commit
-            for record in sorted_records
-            if record.commit.status == "APPLIED"
-        ]
-        recommended_commits = [
-            record.commit
-            for record in sorted_records
-            if record.commit.status == "PARTIAL"
-        ]
+        recommended_commits = [record.commit for record in sorted_records]
 
-        if connected_commits:
-            decision_status = "APPLIED"
+        if recommended_commits:
             matched_decision_items += 1
-        elif recommended_commits:
-            decision_status = "PARTIAL"
-            matched_decision_items += 1
-        else:
-            decision_status = "UNAPPLIED"
 
         decision_items.append(
             DecisionCommitMatchItem(
                 decision_document_id=entry.document_id,
                 decision_title=entry.decision_title,
                 applied_item=entry.applied_item,
-                decision_status=decision_status,
-                connected_commits=connected_commits,
                 recommended_commits=recommended_commits,
             )
         )
 
     return DecisionCommitMatchResponse(
         meeting_id=payload.meeting_id,
-        repository=payload.repository,
+        repository_id=payload.repository_id,
         total_decision_items=len(decision_entries),
         matched_decision_items=matched_decision_items,
         decisions=decision_items,

--- a/app/domains/commit/services/matching.py
+++ b/app/domains/commit/services/matching.py
@@ -307,7 +307,6 @@ async def match_decisions_with_commits(
     if not decision_entries:
         return DecisionCommitMatchResponse(
             meeting_id=payload.meeting_id,
-            project_id=payload.project_id,
             repository=payload.repository,
             total_decision_items=0,
             matched_decision_items=0,
@@ -347,13 +346,6 @@ async def match_decisions_with_commits(
             commit_repository = _first_str(metadata.get("repository"))
 
             if payload.repository and commit_repository != payload.repository:
-                continue
-            commit_project = _first_str(metadata.get("project_id"))
-            if (
-                payload.project_id
-                and commit_project
-                and commit_project != payload.project_id
-            ):
                 continue
 
             commit_document = docs[idx] if idx < len(docs) and docs[idx] else ""
@@ -432,7 +424,6 @@ async def match_decisions_with_commits(
 
     return DecisionCommitMatchResponse(
         meeting_id=payload.meeting_id,
-        project_id=payload.project_id,
         repository=payload.repository,
         total_decision_items=len(decision_entries),
         matched_decision_items=matched_decision_items,

--- a/app/domains/commit/services/matching.py
+++ b/app/domains/commit/services/matching.py
@@ -1,0 +1,440 @@
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from app.core.chroma import get_commit_collection, get_decision_collection
+from app.core.errors import AppServiceError
+from app.domains.commit.schemas import (
+    DecisionCommitMatchItem,
+    DecisionCommitMatchRequest,
+    DecisionCommitMatchResponse,
+    MatchedCommit,
+    MatchScoreBreakdown,
+)
+from app.domains.decision.services.matching_scoring import (
+    ScoringInput,
+    build_connection_reason,
+    calculate_match_score,
+    extract_direction_labels_from_text,
+    extract_module_tokens,
+    extract_tech_keywords,
+    is_opposite_direction,
+    normalize_direction_labels,
+    parse_csv_tokens,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DecisionEntry:
+    document_id: str
+    text: str
+    embedding: list[float] | None
+    decision_title: str
+    applied_item: str
+    direction_labels: set[str]
+    keywords: set[str]
+    modules: set[str]
+
+
+@dataclass(frozen=True)
+class MatchRecord:
+    commit_key: str
+    decision_index: int
+    decision_direction_labels: set[str]
+    commit: MatchedCommit
+
+
+def _first_str(value: Any) -> str | None:
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return None
+
+
+def _first_int(value: Any) -> int | None:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return None
+
+
+def _csv_to_list(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [token for token in (part.strip() for part in value.split(",")) if token]
+
+
+def _to_float_list(value: Any) -> list[float] | None:
+    if value is None:
+        return None
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+    if not isinstance(value, list):
+        return None
+    try:
+        return [float(item) for item in value]
+    except (TypeError, ValueError):
+        return None
+
+
+def _build_commit_key(
+    commit_ref: str | None,
+    commit_hash: str | None,
+    fallback_id: str,
+) -> str:
+    if commit_hash:
+        return f"hash:{commit_hash}"
+    if commit_ref:
+        return f"ref:{commit_ref}"
+    return f"id:{fallback_id}"
+
+
+def _to_decision_entries(raw: dict[str, Any]) -> list[DecisionEntry]:
+    ids = raw.get("ids") or []
+    documents = raw.get("documents") or []
+    metadatas = raw.get("metadatas") or []
+    embeddings = raw.get("embeddings")
+    if embeddings is None:
+        embeddings = []
+
+    entries: list[DecisionEntry] = []
+    for idx, document_id in enumerate(ids):
+        metadata = metadatas[idx] if idx < len(metadatas) and metadatas[idx] else {}
+        text = documents[idx] if idx < len(documents) and documents[idx] else ""
+        embedding = embeddings[idx] if idx < len(embeddings) else None
+
+        decision_title = _first_str(metadata.get("decision_title")) or ""
+        applied_item = _first_str(metadata.get("applied_item")) or ""
+        full_text = f"{decision_title} {applied_item} {text}".strip()
+
+        direction_labels = normalize_direction_labels(
+            _first_str(metadata.get("direction_primary")),
+            _first_str(metadata.get("direction_multi_csv")),
+            _first_str(metadata.get("direction")),
+        )
+        if not direction_labels:
+            direction_labels = extract_direction_labels_from_text(full_text)
+
+        entries.append(
+            DecisionEntry(
+                document_id=document_id,
+                text=text,
+                embedding=_to_float_list(embedding),
+                decision_title=decision_title,
+                applied_item=applied_item,
+                direction_labels=direction_labels,
+                keywords=extract_tech_keywords(full_text),
+                modules=extract_module_tokens(full_text),
+            )
+        )
+    return entries
+
+
+def _normalize_distance(distance: float | None) -> float | None:
+    if distance is None:
+        return None
+    # Chroma cosine distance를 0~1 구간으로 정규화한다.
+    if distance < 0:
+        return 0.0
+    if distance > 1:
+        return 1.0
+    return distance
+
+
+def _resolve_conflicting_matches(records: list[MatchRecord]) -> list[MatchRecord]:
+    grouped: dict[str, list[MatchRecord]] = {}
+    for record in records:
+        grouped.setdefault(record.commit_key, []).append(record)
+
+    kept_ids: set[int] = set()
+    for group in grouped.values():
+        sorted_group = sorted(
+            group,
+            key=lambda record: record.commit.score_breakdown.total,
+            reverse=True,
+        )
+
+        kept_for_commit: list[MatchRecord] = []
+        for candidate in sorted_group:
+            if any(
+                is_opposite_direction(
+                    candidate.decision_direction_labels,
+                    kept.decision_direction_labels,
+                )
+                for kept in kept_for_commit
+            ):
+                continue
+            kept_for_commit.append(candidate)
+
+        kept_ids.update(id(record) for record in kept_for_commit)
+
+    return [record for record in records if id(record) in kept_ids]
+
+
+async def _load_decision_entries(meeting_id: str) -> list[DecisionEntry]:
+    collection = get_decision_collection()
+    try:
+        raw = await asyncio.to_thread(
+            collection.get,
+            where={"meeting_id": meeting_id},
+            include=["documents", "metadatas", "embeddings"],
+        )
+    except Exception as e:
+        raise AppServiceError(
+            "결정사항 임베딩 조회에 실패했습니다.",
+            status_code=502,
+        ) from e
+
+    return _to_decision_entries(raw)
+
+
+async def _query_commit_candidates(
+    query_embedding: list[float],
+    *,
+    n_results: int,
+) -> dict[str, Any]:
+    collection = get_commit_collection()
+    try:
+        return await asyncio.to_thread(
+            collection.query,
+            query_embeddings=[query_embedding],
+            n_results=n_results,
+            include=["documents", "metadatas", "distances"],
+        )
+    except Exception as e:
+        raise AppServiceError(
+            "커밋 후보 조회에 실패했습니다.",
+            status_code=502,
+        ) from e
+
+
+def _build_match_record(
+    *,
+    decision: DecisionEntry,
+    decision_index: int,
+    commit_id: str,
+    commit_document: str,
+    metadata: dict[str, Any],
+    distance: float | None,
+) -> MatchRecord | None:
+    stored_commit_id = _first_int(metadata.get("commit_id"))
+    commit_ref = _first_str(metadata.get("commit_ref"))
+    commit_hash = _first_str(metadata.get("commit_hash"))
+    repository = _first_str(metadata.get("repository"))
+
+    direction_primary = _first_str(metadata.get("direction_primary")) or _first_str(
+        metadata.get("direction")
+    )
+    direction_multi_csv = _first_str(metadata.get("direction_multi_csv")) or _first_str(
+        metadata.get("direction")
+    )
+    direction_multi = _csv_to_list(direction_multi_csv)
+
+    tech_keywords_csv = _first_str(metadata.get("tech_keywords_csv"))
+    module_tags_csv = _first_str(metadata.get("module_tags_csv")) or _first_str(
+        metadata.get("path_tokens_csv")
+    )
+
+    commit_keywords = extract_tech_keywords(
+        commit_document,
+        tech_keywords_csv,
+    )
+    commit_modules = extract_module_tokens(commit_document, module_tags_csv)
+    commit_direction_labels = normalize_direction_labels(
+        direction_primary,
+        direction_multi_csv,
+    )
+    if not commit_direction_labels:
+        commit_direction_labels = extract_direction_labels_from_text(commit_document)
+
+    score = calculate_match_score(
+        ScoringInput(
+            semantic_distance=_normalize_distance(distance),
+            decision_text=decision.text,
+            commit_text=commit_document,
+            commit_message=(
+                _first_str(metadata.get("commit_message")) or commit_document
+            ),
+            decision_direction_labels=decision.direction_labels,
+            commit_direction_labels=commit_direction_labels,
+            decision_keywords=decision.keywords,
+            commit_keywords=commit_keywords,
+            decision_modules=decision.modules,
+            commit_modules=commit_modules,
+        )
+    )
+
+    if score.total < 50:
+        return None
+
+    matched_commit = MatchedCommit(
+        commit_id=stored_commit_id,
+        commit_ref=commit_ref,
+        commit_hash=commit_hash,
+        repository=repository,
+        status=score.status,
+        confidence=score.total,
+        reason=build_connection_reason(score),
+        score_breakdown=MatchScoreBreakdown(
+            semantic=score.semantic,
+            keyword=score.keyword,
+            context=score.context,
+            penalty=score.penalty,
+            total=score.total,
+        ),
+        direction_primary=direction_primary,
+        direction_multi=direction_multi,
+        tech_keywords=sorted(parse_csv_tokens(tech_keywords_csv)),
+        module_tags=sorted(parse_csv_tokens(module_tags_csv)),
+    )
+
+    return MatchRecord(
+        commit_key=_build_commit_key(commit_ref, commit_hash, commit_id),
+        decision_index=decision_index,
+        decision_direction_labels=decision.direction_labels,
+        commit=matched_commit,
+    )
+
+
+async def match_decisions_with_commits(
+    payload: DecisionCommitMatchRequest,
+) -> DecisionCommitMatchResponse:
+    decision_entries = await _load_decision_entries(payload.meeting_id)
+    if not decision_entries:
+        return DecisionCommitMatchResponse(
+            meeting_id=payload.meeting_id,
+            project_id=payload.project_id,
+            repository=payload.repository,
+            total_decision_items=0,
+            matched_decision_items=0,
+            decisions=[],
+        )
+
+    pool_size = min(100, max(payload.top_k, payload.top_k * 5))
+    matched_by_decision: dict[int, dict[str, MatchRecord]] = {
+        idx: {} for idx in range(len(decision_entries))
+    }
+
+    for decision_index, decision in enumerate(decision_entries):
+        if not decision.embedding:
+            logger.warning(
+                "결정사항 문서에 임베딩이 없어 후보 조회를 건너뜁니다: %s",
+                decision.document_id,
+            )
+            continue
+
+        query_result = await _query_commit_candidates(
+            decision.embedding,
+            n_results=pool_size,
+        )
+
+        ids_nested = query_result.get("ids") or [[]]
+        docs_nested = query_result.get("documents") or [[]]
+        metas_nested = query_result.get("metadatas") or [[]]
+        distances_nested = query_result.get("distances") or [[]]
+
+        ids = ids_nested[0] if ids_nested else []
+        docs = docs_nested[0] if docs_nested else []
+        metadatas = metas_nested[0] if metas_nested else []
+        distances = distances_nested[0] if distances_nested else []
+
+        for idx, commit_id in enumerate(ids):
+            metadata = metadatas[idx] if idx < len(metadatas) and metadatas[idx] else {}
+            commit_repository = _first_str(metadata.get("repository"))
+
+            if payload.repository and commit_repository != payload.repository:
+                continue
+            commit_project = _first_str(metadata.get("project_id"))
+            if (
+                payload.project_id
+                and commit_project
+                and commit_project != payload.project_id
+            ):
+                continue
+
+            commit_document = docs[idx] if idx < len(docs) and docs[idx] else ""
+            distance = distances[idx] if idx < len(distances) else None
+            record = _build_match_record(
+                decision=decision,
+                decision_index=decision_index,
+                commit_id=commit_id,
+                commit_document=commit_document,
+                metadata=metadata,
+                distance=distance,
+            )
+            if not record:
+                continue
+
+            existing = matched_by_decision[decision_index].get(record.commit_key)
+            if (
+                existing is None
+                or record.commit.score_breakdown.total
+                > existing.commit.score_breakdown.total
+            ):
+                matched_by_decision[decision_index][record.commit_key] = record
+
+    flattened_records = [
+        record
+        for records in matched_by_decision.values()
+        for record in records.values()
+    ]
+    resolved_records = _resolve_conflicting_matches(flattened_records)
+
+    records_by_decision: dict[int, list[MatchRecord]] = {
+        idx: [] for idx in matched_by_decision
+    }
+    for record in resolved_records:
+        records_by_decision[record.decision_index].append(record)
+
+    decision_items: list[DecisionCommitMatchItem] = []
+    matched_decision_items = 0
+    for idx, entry in enumerate(decision_entries):
+        sorted_records = sorted(
+            records_by_decision[idx],
+            key=lambda record: record.commit.score_breakdown.total,
+            reverse=True,
+        )[: payload.top_k]
+
+        connected_commits = [
+            record.commit
+            for record in sorted_records
+            if record.commit.status == "APPLIED"
+        ]
+        recommended_commits = [
+            record.commit
+            for record in sorted_records
+            if record.commit.status == "PARTIAL"
+        ]
+
+        if connected_commits:
+            decision_status = "APPLIED"
+            matched_decision_items += 1
+        elif recommended_commits:
+            decision_status = "PARTIAL"
+            matched_decision_items += 1
+        else:
+            decision_status = "UNAPPLIED"
+
+        decision_items.append(
+            DecisionCommitMatchItem(
+                decision_document_id=entry.document_id,
+                decision_title=entry.decision_title,
+                applied_item=entry.applied_item,
+                decision_status=decision_status,
+                connected_commits=connected_commits,
+                recommended_commits=recommended_commits,
+            )
+        )
+
+    return DecisionCommitMatchResponse(
+        meeting_id=payload.meeting_id,
+        project_id=payload.project_id,
+        repository=payload.repository,
+        total_decision_items=len(decision_entries),
+        matched_decision_items=matched_decision_items,
+        decisions=decision_items,
+    )

--- a/app/domains/commit/services/summarize.py
+++ b/app/domains/commit/services/summarize.py
@@ -218,6 +218,7 @@ async def summarize_commit(
 
 async def generate_embedding_text(
     commit_id: int,
+    commit_hash: str | None,
     repository: str,
     message: str,
     changed_file_list: list[ChangedFile],
@@ -258,6 +259,8 @@ async def generate_embedding_text(
             "tech_keywords_csv": ",".join(parsed.tech_keywords),
             "module_tags_csv": ",".join(parsed.module_tags),
         }
+        if commit_hash:
+            metadata["commit_hash"] = commit_hash
         await asyncio.to_thread(
             collection.upsert,
             ids=[doc_id],

--- a/app/domains/commit/services/summarize.py
+++ b/app/domains/commit/services/summarize.py
@@ -219,7 +219,7 @@ async def summarize_commit(
 async def generate_embedding_text(
     commit_id: int,
     commit_hash: str | None,
-    repository: str,
+    repository_id: int,
     message: str,
     changed_file_list: list[ChangedFile],
 ) -> None:
@@ -236,7 +236,7 @@ async def generate_embedding_text(
 
         # 2) 스펙에 맞는 임베딩용 텍스트 조합
         commit_subject = message.split("\n", 1)[0].strip()
-        title = f"{repository} {commit_subject}"
+        title = f"repository-{repository_id} {commit_subject}"
         text_parts = [f"변경요약: {parsed.summary}"]
         if parsed.tech_keywords:
             text_parts.append(f"기술키워드: {','.join(parsed.tech_keywords)}")
@@ -254,7 +254,8 @@ async def generate_embedding_text(
         doc_id = f"commit_{commit_id}"
         metadata = {
             "commit_id": commit_id,
-            "repository": repository,
+            "commit_message": commit_subject,
+            "repository_id": repository_id,
             "direction": ",".join(parsed.directions),
             "tech_keywords_csv": ",".join(parsed.tech_keywords),
             "module_tags_csv": ",".join(parsed.module_tags),

--- a/app/domains/decision/services/matching_scoring.py
+++ b/app/domains/decision/services/matching_scoring.py
@@ -1,0 +1,458 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+MatchStatus = Literal["APPLIED", "PARTIAL", "UNAPPLIED"]
+
+_TOKEN_PATTERN = re.compile(r"[A-Za-z][A-Za-z0-9._/-]{1,}|[가-힣]{2,}")
+_PATH_LIKE_PATTERN = re.compile(r"[A-Za-z0-9._/-]+")
+
+_GENERIC_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "api",
+    "bug",
+    "chore",
+    "change",
+    "changes",
+    "code",
+    "commit",
+    "config",
+    "feature",
+    "feat",
+    "fix",
+    "hotfix",
+    "improve",
+    "issue",
+    "minor",
+    "patch",
+    "refactor",
+    "test",
+    "text",
+    "title",
+    "todo",
+    "update",
+    "work",
+    "summary",
+    "변경요약",
+    "변경방향",
+    "파일맥락",
+    "기술키워드",
+    "근거",
+    "적용사항",
+    "기능",
+    "개선",
+    "구현",
+    "수정",
+    "작업",
+    "적용",
+    "정리",
+    "테스트",
+    "추가",
+    "변경",
+    "도입",
+    "삭제",
+    "제거",
+    "전환",
+}
+
+_MODULE_STOPWORDS = {
+    "api",
+    "app",
+    "build",
+    "config",
+    "controller",
+    "core",
+    "domain",
+    "dto",
+    "helper",
+    "lib",
+    "main",
+    "model",
+    "repo",
+    "repository",
+    "service",
+    "src",
+    "test",
+    "tests",
+    "text",
+    "title",
+    "utils",
+    "변경요약",
+    "변경방향",
+    "파일맥락",
+    "기술키워드",
+    "근거",
+    "적용사항",
+}
+
+_ABSTRACT_COMMIT_WORDS = {
+    "change",
+    "chore",
+    "cleanup",
+    "fix",
+    "minor",
+    "patch",
+    "refactor",
+    "update",
+    "수정",
+    "정리",
+    "리팩토링",
+    "변경",
+}
+
+_POSITIVE_DIRECTION_WORDS = {
+    "add",
+    "adopt",
+    "apply",
+    "create",
+    "enable",
+    "introduce",
+    "migrate",
+    "onboard",
+    "도입",
+    "추가",
+    "적용",
+    "전환",
+    "활성화",
+    "확대",
+}
+
+_NEGATIVE_DIRECTION_WORDS = {
+    "delete",
+    "disable",
+    "drop",
+    "remove",
+    "retire",
+    "revert",
+    "rollback",
+    "삭제",
+    "비활성화",
+    "제거",
+    "중단",
+    "철회",
+    "폐기",
+}
+
+_LABEL_ALIASES = {
+    "positive": "positive",
+    "negative": "negative",
+    "add": "positive",
+    "adopt": "positive",
+    "apply": "positive",
+    "create": "positive",
+    "enable": "positive",
+    "introduce": "positive",
+    "migrate": "positive",
+    "onboard": "positive",
+    "remove": "negative",
+    "delete": "negative",
+    "disable": "negative",
+    "drop": "negative",
+    "revert": "negative",
+    "rollback": "negative",
+    "retire": "negative",
+    "도입": "positive",
+    "추가": "positive",
+    "적용": "positive",
+    "전환": "positive",
+    "활성화": "positive",
+    "확대": "positive",
+    "제거": "negative",
+    "삭제": "negative",
+    "비활성화": "negative",
+    "롤백": "negative",
+    "중단": "negative",
+    "철회": "negative",
+    "폐기": "negative",
+}
+
+
+@dataclass(frozen=True)
+class ScoreBreakdown:
+    semantic: int
+    keyword: int
+    context: int
+    penalty: int
+    total: int
+    status: MatchStatus
+    is_opposite_direction: bool
+    is_goal_mismatch: bool
+
+
+@dataclass(frozen=True)
+class ScoringInput:
+    semantic_distance: float | None
+    decision_text: str
+    commit_text: str
+    commit_message: str
+    decision_direction_labels: set[str]
+    commit_direction_labels: set[str]
+    decision_keywords: set[str]
+    commit_keywords: set[str]
+    decision_modules: set[str]
+    commit_modules: set[str]
+
+
+def _normalize_token(token: str) -> str:
+    return token.strip().lower()
+
+
+def _split_compound_token(token: str) -> set[str]:
+    normalized = _normalize_token(token)
+    if not normalized:
+        return set()
+
+    parts = re.split(r"[._/\-]+", normalized)
+    return {part for part in parts if part}
+
+
+def parse_csv_tokens(raw: str | None) -> set[str]:
+    if not raw:
+        return set()
+
+    tokens: set[str] = set()
+    for part in re.split(r"[,\n;|]+", raw):
+        stripped = _normalize_token(part)
+        if not stripped:
+            continue
+        tokens.add(stripped)
+        tokens.update(_split_compound_token(stripped))
+    return tokens
+
+
+def extract_direction_labels_from_text(text: str) -> set[str]:
+    labels: set[str] = set()
+    for token in extract_text_tokens(text):
+        if token in _POSITIVE_DIRECTION_WORDS:
+            labels.add("positive")
+        if token in _NEGATIVE_DIRECTION_WORDS:
+            labels.add("negative")
+    return labels
+
+
+def normalize_direction_labels(*values: str | None) -> set[str]:
+    labels: set[str] = set()
+    for value in values:
+        for token in parse_csv_tokens(value):
+            label = _LABEL_ALIASES.get(token)
+            if label:
+                labels.add(label)
+    return labels
+
+
+def extract_text_tokens(text: str) -> set[str]:
+    if not text:
+        return set()
+
+    tokens: set[str] = set()
+    for raw in _TOKEN_PATTERN.findall(text):
+        normalized = _normalize_token(raw)
+        if not normalized:
+            continue
+        tokens.add(normalized)
+        tokens.update(_split_compound_token(normalized))
+    return tokens
+
+
+def extract_tech_keywords(text: str, csv_keywords: str | None = None) -> set[str]:
+    candidate_tokens = extract_text_tokens(text)
+    candidate_tokens.update(parse_csv_tokens(csv_keywords))
+
+    return {
+        token
+        for token in candidate_tokens
+        if len(token) >= 2 and token not in _GENERIC_STOPWORDS
+    }
+
+
+def extract_module_tokens(text: str, csv_modules: str | None = None) -> set[str]:
+    candidate_tokens = parse_csv_tokens(csv_modules)
+    for path_like in _PATH_LIKE_PATTERN.findall(text or ""):
+        candidate_tokens.add(_normalize_token(path_like))
+        candidate_tokens.update(_split_compound_token(path_like))
+
+    return {
+        token
+        for token in candidate_tokens
+        if len(token) >= 2 and token not in _MODULE_STOPWORDS
+    }
+
+
+def is_opposite_direction(
+    decision_labels: set[str],
+    commit_labels: set[str],
+) -> bool:
+    if not decision_labels or not commit_labels:
+        return False
+    return (
+        "positive" in decision_labels
+        and "negative" in commit_labels
+        or "negative" in decision_labels
+        and "positive" in commit_labels
+    )
+
+
+def score_semantic(
+    semantic_distance: float | None,
+    *,
+    opposite_direction: bool,
+) -> int:
+    if opposite_direction:
+        return 0
+    if semantic_distance is None:
+        return 0
+
+    normalized_distance = max(0.0, min(1.0, semantic_distance))
+    return int(round((1.0 - normalized_distance) * 50))
+
+
+def score_keyword_match(
+    decision_keywords: set[str],
+    commit_keywords: set[str],
+) -> int:
+    overlap_count = len(decision_keywords & commit_keywords)
+    if overlap_count <= 0:
+        return 0
+    if overlap_count == 1:
+        return 15
+    if overlap_count == 2:
+        return 25
+    return 30
+
+
+def score_context_match(
+    decision_modules: set[str],
+    commit_modules: set[str],
+) -> int:
+    if not decision_modules or not commit_modules:
+        return 0
+
+    overlap = decision_modules & commit_modules
+    if len(overlap) >= 2:
+        return 20
+    if len(overlap) == 1:
+        return 10
+
+    # 간접 연관: prefix/substring 기반 1회라도 발견되면 10점.
+    for decision_token in decision_modules:
+        for commit_token in commit_modules:
+            if decision_token in commit_token or commit_token in decision_token:
+                return 10
+    return 0
+
+
+def is_abstract_commit_message(commit_message: str) -> bool:
+    tokens = extract_text_tokens(commit_message)
+    if not tokens:
+        return True
+
+    meaningful_tokens = tokens - _ABSTRACT_COMMIT_WORDS
+    if not meaningful_tokens:
+        return True
+
+    if len(tokens) <= 3 and len(meaningful_tokens) <= 1:
+        return True
+    return False
+
+
+def is_ambiguous_decision(
+    decision_text: str,
+    decision_keywords: set[str],
+    decision_modules: set[str],
+) -> bool:
+    decision_tokens = extract_text_tokens(decision_text)
+    if len(decision_tokens) < 3:
+        return True
+    if not decision_keywords and not decision_modules:
+        return True
+    return False
+
+
+def resolve_match_status(total_score: int) -> MatchStatus:
+    if total_score >= 70:
+        return "APPLIED"
+    if total_score >= 50:
+        return "PARTIAL"
+    return "UNAPPLIED"
+
+
+def build_connection_reason(score: ScoreBreakdown) -> str:
+    if score.total < 50:
+        return "신뢰도 임계치 미달로 자동 연결하지 않았습니다."
+    if score.is_opposite_direction:
+        return "의미 방향이 반대여서 자동 연결을 제한했습니다."
+    if score.is_goal_mismatch:
+        return "키워드는 유사하지만 변경 목적이 달라 자동 연결을 제한했습니다."
+
+    reason_parts: list[str] = []
+    if score.semantic >= 30:
+        reason_parts.append("의미 유사성이 높습니다")
+    elif score.semantic > 0:
+        reason_parts.append("의미 유사성이 일부 확인됩니다")
+
+    if score.keyword >= 25:
+        reason_parts.append("핵심 기술 키워드가 다수 일치합니다")
+    elif score.keyword >= 15:
+        reason_parts.append("핵심 기술 키워드가 일부 일치합니다")
+
+    if score.context >= 20:
+        reason_parts.append("파일/모듈 맥락이 직접 일치합니다")
+    elif score.context >= 10:
+        reason_parts.append("파일/모듈 맥락이 간접 일치합니다")
+
+    if not reason_parts:
+        reason_parts.append("복합 신호 기반으로 부분 일치가 확인됩니다")
+    return ", ".join(reason_parts) + "."
+
+
+def calculate_match_score(payload: ScoringInput) -> ScoreBreakdown:
+    opposite_direction = is_opposite_direction(
+        payload.decision_direction_labels,
+        payload.commit_direction_labels,
+    )
+    semantic = score_semantic(
+        payload.semantic_distance,
+        opposite_direction=opposite_direction,
+    )
+    keyword = score_keyword_match(payload.decision_keywords, payload.commit_keywords)
+    context = score_context_match(payload.decision_modules, payload.commit_modules)
+
+    goal_mismatch = keyword >= 15 and semantic <= 10
+    if goal_mismatch:
+        return ScoreBreakdown(
+            semantic=semantic,
+            keyword=keyword,
+            context=context,
+            penalty=0,
+            total=0,
+            status="UNAPPLIED",
+            is_opposite_direction=opposite_direction,
+            is_goal_mismatch=True,
+        )
+
+    base_score = semantic + keyword + context
+    penalty = 0
+    if is_abstract_commit_message(payload.commit_message):
+        penalty += 10
+    if is_ambiguous_decision(
+        payload.decision_text,
+        payload.decision_keywords,
+        payload.decision_modules,
+    ):
+        penalty += 10
+
+    total = max(0, min(100, base_score - penalty))
+    return ScoreBreakdown(
+        semantic=semantic,
+        keyword=keyword,
+        context=context,
+        penalty=penalty,
+        total=total,
+        status=resolve_match_status(total),
+        is_opposite_direction=opposite_direction,
+        is_goal_mismatch=False,
+    )

--- a/tests/test_decision_commit_matching.py
+++ b/tests/test_decision_commit_matching.py
@@ -1,0 +1,453 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.background import BackgroundTasks
+
+from app.core.errors import AppServiceError
+from app.domains.commit.router import analyze_commit
+from app.domains.commit.schemas import (
+    ChangedFile,
+    CommitAnalyzeRequest,
+    DecisionCommitMatchRequest,
+    DecisionCommitMatchResponse,
+)
+from app.domains.commit.services.matching import (
+    _to_decision_entries,
+    match_decisions_with_commits,
+)
+from app.domains.commit.services.summarize import generate_embedding_text
+from app.main import app
+
+
+def _build_match_payload() -> dict:
+    return {
+        "meeting_id": "meeting-123",
+        "project_id": "project-abc",
+        "repository": "whylog/web",
+        "top_k": 5,
+    }
+
+
+class TestDecisionCommitMatchingService:
+    def test_decision_entries_accept_chroma_numpy_embeddings(self):
+        np = pytest.importorskip("numpy")
+        raw = {
+            "ids": ["meeting-123_card0_item0"],
+            "documents": ["title: Redis 도입 | text: 적용사항: redis 도입"],
+            "metadatas": [
+                {
+                    "decision_title": "Redis 도입",
+                    "applied_item": "redis 도입",
+                }
+            ],
+            "embeddings": np.array([[0.1, 0.2, 0.3]]),
+        }
+
+        entries = _to_decision_entries(raw)
+
+        assert entries[0].embedding == [0.1, 0.2, 0.3]
+
+    @pytest.mark.asyncio
+    async def test_matches_applied_and_partial_commits(self):
+        decision_collection = MagicMock()
+        decision_collection.get.return_value = {
+            "ids": ["meeting-123_card0_item0"],
+            "documents": [
+                (
+                    "title: 알림 시스템 개선 | text: 적용사항: "
+                    "notification queue redis "
+                    "kafka rabbitmq 도입 | 근거: 처리 지연 감소"
+                )
+            ],
+            "metadatas": [
+                {
+                    "decision_title": "알림 시스템 개선",
+                    "applied_item": "notification queue redis kafka rabbitmq 도입",
+                }
+            ],
+            "embeddings": [[0.11, 0.22, 0.33]],
+        }
+
+        commit_collection = MagicMock()
+        commit_collection.query.return_value = {
+            "ids": [["commit_1", "commit_2", "commit_3"]],
+            "documents": [
+                [
+                    (
+                        "title: whylog/web feat | text: 변경요약: redis queue 도입 "
+                        "| 기술키워드: redis,kafka,rabbitmq | 변경방향: add "
+                        "| 파일맥락: notification,queue"
+                    ),
+                    (
+                        "title: whylog/web feat | text: 변경요약: "
+                        "redis kafka 설정 추가 "
+                        "| 기술키워드: redis,kafka | 변경방향: add "
+                        "| 파일맥락: notification,queue"
+                    ),
+                    (
+                        "title: whylog/web fix | text: 변경요약: billing 버그 수정 "
+                        "| 기술키워드: billing | 변경방향: modify | 파일맥락: billing"
+                    ),
+                ]
+            ],
+            "metadatas": [
+                [
+                    {
+                        "commit_ref": "c1",
+                        "commit_id": 1,
+                        "commit_hash": "h1",
+                        "repository": "whylog/web",
+                        "direction_primary": "add",
+                        "direction_multi_csv": "add",
+                        "tech_keywords_csv": "redis,kafka,rabbitmq",
+                        "module_tags_csv": "notification,queue",
+                        "commit_message": "feat: introduce redis queue",
+                    },
+                    {
+                        "commit_ref": "c2",
+                        "commit_hash": "h2",
+                        "repository": "whylog/web",
+                        "direction_primary": "add",
+                        "direction_multi_csv": "add",
+                        "tech_keywords_csv": "redis,kafka",
+                        "module_tags_csv": "notification,queue",
+                        "commit_message": "feat: add redis config",
+                    },
+                    {
+                        "commit_ref": "c3",
+                        "commit_hash": "h3",
+                        "repository": "whylog/web",
+                        "direction_primary": "modify",
+                        "direction_multi_csv": "modify",
+                        "tech_keywords_csv": "billing",
+                        "module_tags_csv": "billing",
+                        "commit_message": "fix billing",
+                    },
+                ]
+            ],
+            "distances": [[0.02, 0.78, 0.90]],
+        }
+
+        with (
+            patch(
+                "app.domains.commit.services.matching.get_decision_collection",
+                return_value=decision_collection,
+            ),
+            patch(
+                "app.domains.commit.services.matching.get_commit_collection",
+                return_value=commit_collection,
+            ),
+        ):
+            result = await match_decisions_with_commits(
+                DecisionCommitMatchRequest(**_build_match_payload())
+            )
+
+        assert result.total_decision_items == 1
+        assert result.matched_decision_items == 1
+        item = result.decisions[0]
+        assert item.decision_status == "APPLIED"
+        assert len(item.connected_commits) == 1
+        assert len(item.recommended_commits) == 1
+        assert item.connected_commits[0].commit_id == 1
+        assert item.connected_commits[0].commit_hash == "h1"
+        assert item.connected_commits[0].confidence >= 70
+        assert item.recommended_commits[0].status == "PARTIAL"
+
+    @pytest.mark.asyncio
+    async def test_opposite_direction_candidate_is_not_matched(self):
+        decision_collection = MagicMock()
+        decision_collection.get.return_value = {
+            "ids": ["meeting-123_card0_item0"],
+            "documents": [
+                "title: Redis 제거 | text: 적용사항: notification redis 제거"
+            ],
+            "metadatas": [
+                {
+                    "decision_title": "Redis 제거",
+                    "applied_item": "notification redis 제거",
+                }
+            ],
+            "embeddings": [[0.1, 0.2]],
+        }
+
+        commit_collection = MagicMock()
+        commit_collection.query.return_value = {
+            "ids": [["commit_1"]],
+            "documents": [
+                ["변경요약: redis 도입 | 기술키워드: redis | 파일맥락: notification"]
+            ],
+            "metadatas": [
+                [
+                    {
+                        "commit_ref": "c1",
+                        "commit_hash": "h1",
+                        "repository": "whylog/web",
+                        "direction_primary": "add",
+                        "direction_multi_csv": "add",
+                        "tech_keywords_csv": "redis",
+                        "module_tags_csv": "notification",
+                        "commit_message": "feat: introduce redis",
+                    }
+                ]
+            ],
+            "distances": [[0.01]],
+        }
+
+        with (
+            patch(
+                "app.domains.commit.services.matching.get_decision_collection",
+                return_value=decision_collection,
+            ),
+            patch(
+                "app.domains.commit.services.matching.get_commit_collection",
+                return_value=commit_collection,
+            ),
+        ):
+            result = await match_decisions_with_commits(
+                DecisionCommitMatchRequest(**_build_match_payload())
+            )
+
+        item = result.decisions[0]
+        assert item.decision_status == "UNAPPLIED"
+        assert item.connected_commits == []
+        assert item.recommended_commits == []
+
+    @pytest.mark.asyncio
+    async def test_same_commit_is_removed_from_opposite_decision(self):
+        decision_collection = MagicMock()
+        decision_collection.get.return_value = {
+            "ids": ["meeting-123_card0_item0", "meeting-123_card1_item0"],
+            "documents": [
+                (
+                    "title: Redis 도입 | text: 적용사항: notification redis kafka "
+                    "rabbitmq 도입"
+                ),
+                (
+                    "title: Redis 제거 | text: 적용사항: notification redis kafka "
+                    "rabbitmq 제거"
+                ),
+            ],
+            "metadatas": [
+                {
+                    "decision_title": "Redis 도입",
+                    "applied_item": "notification redis kafka rabbitmq 도입",
+                },
+                {
+                    "decision_title": "Redis 제거",
+                    "applied_item": "notification redis kafka rabbitmq 제거",
+                },
+            ],
+            "embeddings": [[0.1, 0.2], [0.3, 0.4]],
+        }
+
+        commit_collection = MagicMock()
+        commit_collection.query.side_effect = [
+            {
+                "ids": [["commit_shared"]],
+                "documents": [
+                    [
+                        (
+                            "변경요약: redis queue 도입 | 기술키워드: redis,kafka,"
+                            "rabbitmq | 파일맥락: notification,queue"
+                        )
+                    ]
+                ],
+                "metadatas": [
+                    [
+                        {
+                            "commit_ref": "c-shared",
+                            "commit_hash": "h-shared",
+                            "repository": "whylog/web",
+                            "direction_primary": "add",
+                            "direction_multi_csv": "add",
+                            "tech_keywords_csv": "redis,kafka,rabbitmq",
+                            "module_tags_csv": "notification,queue",
+                            "commit_message": "feat: introduce redis queue",
+                        }
+                    ]
+                ],
+                "distances": [[0.05]],
+            },
+            {
+                "ids": [["commit_shared"]],
+                "documents": [
+                    [
+                        (
+                            "변경요약: redis queue 도입 | 기술키워드: redis,kafka,"
+                            "rabbitmq | 파일맥락: notification,queue"
+                        )
+                    ]
+                ],
+                "metadatas": [
+                    [
+                        {
+                            "commit_ref": "c-shared",
+                            "commit_hash": "h-shared",
+                            "repository": "whylog/web",
+                            "direction_primary": "add",
+                            "direction_multi_csv": "add",
+                            "tech_keywords_csv": "redis,kafka,rabbitmq",
+                            "module_tags_csv": "notification,queue",
+                            "commit_message": "feat: introduce redis queue",
+                        }
+                    ]
+                ],
+                "distances": [[0.20]],
+            },
+        ]
+
+        with (
+            patch(
+                "app.domains.commit.services.matching.get_decision_collection",
+                return_value=decision_collection,
+            ),
+            patch(
+                "app.domains.commit.services.matching.get_commit_collection",
+                return_value=commit_collection,
+            ),
+        ):
+            result = await match_decisions_with_commits(
+                DecisionCommitMatchRequest(**_build_match_payload())
+            )
+
+        first_item = result.decisions[0]
+        second_item = result.decisions[1]
+        assert first_item.decision_status == "APPLIED"
+        assert len(first_item.connected_commits) == 1
+        assert second_item.decision_status == "UNAPPLIED"
+        assert second_item.connected_commits == []
+        assert second_item.recommended_commits == []
+
+
+class TestDecisionCommitMatchingEndpoint:
+    client = TestClient(app)
+
+    def test_match_endpoint_success(self):
+        mock_result = DecisionCommitMatchResponse(
+            meeting_id="meeting-123",
+            project_id="project-abc",
+            repository="whylog/web",
+            total_decision_items=1,
+            matched_decision_items=1,
+            decisions=[],
+        )
+
+        with patch(
+            "app.domains.commit.router.match_decisions_with_commits",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            response = self.client.post(
+                "/api/commit/match",
+                json=_build_match_payload(),
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["isSuccess"] is True
+        assert body["code"] == "COMMIT_MATCH_200"
+        assert body["result"]["meeting_id"] == "meeting-123"
+
+    def test_match_endpoint_validation_error(self):
+        payload = _build_match_payload()
+        payload["top_k"] = 0
+
+        response = self.client.post("/api/commit/match", json=payload)
+
+        assert response.status_code == 422
+        body = response.json()
+        assert body["isSuccess"] is False
+        assert body["code"] == "COMMON_422"
+
+    def test_match_endpoint_service_failure(self):
+        with patch(
+            "app.domains.commit.router.match_decisions_with_commits",
+            new_callable=AsyncMock,
+            side_effect=AppServiceError("커밋 후보 조회 실패", status_code=502),
+        ):
+            response = self.client.post(
+                "/api/commit/match",
+                json=_build_match_payload(),
+            )
+
+        assert response.status_code == 502
+        body = response.json()
+        assert body["isSuccess"] is False
+        assert body["code"] == "COMMON_502"
+
+
+class TestCommitAnalyzeHashMetadata:
+    @pytest.mark.asyncio
+    async def test_analyze_commit_passes_commit_hash_to_background_embedding(self):
+        background_tasks = BackgroundTasks()
+        request = CommitAnalyzeRequest(
+            commit_id=1,
+            commit_hash="b8fd9ad",
+            repository="whylog/web",
+            message="feat: API 구현",
+            changed_file_list=[
+                ChangedFile(
+                    file_name="app/domains/api.py",
+                    changed_code="+def handler():\n+    return True",
+                )
+            ],
+        )
+
+        with patch(
+            "app.domains.commit.router.summarize_commit",
+            new_callable=AsyncMock,
+            return_value="API를 구현했습니다.",
+        ):
+            response = await analyze_commit(request, background_tasks)
+
+        assert response.result.commit_id == 1
+        task = background_tasks.tasks[0]
+        assert task.args[0] == 1
+        assert task.args[1] == "b8fd9ad"
+
+    @pytest.mark.asyncio
+    async def test_generate_embedding_text_stores_commit_hash_metadata(self):
+        collection = MagicMock()
+
+        with (
+            patch(
+                "app.domains.commit.services.summarize._get_client",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "app.domains.commit.services.summarize._call_gemini",
+                new_callable=AsyncMock,
+                return_value=(
+                    "변경요약: API 엔드포인트를 추가했습니다.\n"
+                    "기술키워드: fastapi\n"
+                    "변경방향: add\n"
+                    "파일맥락: commit"
+                ),
+            ),
+            patch(
+                "app.domains.commit.services.summarize._generate_embedding",
+                new_callable=AsyncMock,
+                return_value=[0.1, 0.2, 0.3],
+            ),
+            patch(
+                "app.domains.commit.services.summarize.get_commit_collection",
+                return_value=collection,
+            ),
+        ):
+            await generate_embedding_text(
+                1,
+                "b8fd9ad",
+                "whylog/web",
+                "feat: API 구현",
+                [
+                    ChangedFile(
+                        file_name="app/domains/api.py",
+                        changed_code="+def handler():\n+    return True",
+                    )
+                ],
+            )
+
+        _, kwargs = collection.upsert.call_args
+        assert kwargs["metadatas"][0]["commit_id"] == 1
+        assert kwargs["metadatas"][0]["commit_hash"] == "b8fd9ad"

--- a/tests/test_decision_commit_matching.py
+++ b/tests/test_decision_commit_matching.py
@@ -23,7 +23,7 @@ from app.main import app
 def _build_match_payload() -> dict:
     return {
         "meeting_id": "meeting-123",
-        "repository": "whylog/web",
+        "repository_id": 1,
         "top_k": 5,
     }
 
@@ -48,7 +48,7 @@ class TestDecisionCommitMatchingService:
         assert entries[0].embedding == [0.1, 0.2, 0.3]
 
     @pytest.mark.asyncio
-    async def test_matches_applied_and_partial_commits(self):
+    async def test_returns_recommended_commits_sorted_by_confidence(self):
         decision_collection = MagicMock()
         decision_collection.get.return_value = {
             "ids": ["meeting-123_card0_item0"],
@@ -96,7 +96,7 @@ class TestDecisionCommitMatchingService:
                         "commit_ref": "c1",
                         "commit_id": 1,
                         "commit_hash": "h1",
-                        "repository": "whylog/web",
+                        "repository_id": 1,
                         "direction_primary": "add",
                         "direction_multi_csv": "add",
                         "tech_keywords_csv": "redis,kafka,rabbitmq",
@@ -106,7 +106,7 @@ class TestDecisionCommitMatchingService:
                     {
                         "commit_ref": "c2",
                         "commit_hash": "h2",
-                        "repository": "whylog/web",
+                        "repository_id": 1,
                         "direction_primary": "add",
                         "direction_multi_csv": "add",
                         "tech_keywords_csv": "redis,kafka",
@@ -116,7 +116,7 @@ class TestDecisionCommitMatchingService:
                     {
                         "commit_ref": "c3",
                         "commit_hash": "h3",
-                        "repository": "whylog/web",
+                        "repository_id": 1,
                         "direction_primary": "modify",
                         "direction_multi_csv": "modify",
                         "tech_keywords_csv": "billing",
@@ -145,13 +145,21 @@ class TestDecisionCommitMatchingService:
         assert result.total_decision_items == 1
         assert result.matched_decision_items == 1
         item = result.decisions[0]
-        assert item.decision_status == "APPLIED"
-        assert len(item.connected_commits) == 1
-        assert len(item.recommended_commits) == 1
-        assert item.connected_commits[0].commit_id == 1
-        assert item.connected_commits[0].commit_hash == "h1"
-        assert item.connected_commits[0].confidence >= 70
-        assert item.recommended_commits[0].status == "PARTIAL"
+        assert len(item.recommended_commits) == 2
+        assert item.recommended_commits[0].commit_id == 1
+        assert item.recommended_commits[0].commit_hash == "h1"
+        assert item.recommended_commits[0].commit_message == (
+            "feat: introduce redis queue"
+        )
+        assert item.recommended_commits[0].confidence >= 70
+        assert "총" in item.recommended_commits[0].reason
+        assert "겹친 키워드" in item.recommended_commits[0].reason
+        assert item.recommended_commits[1].commit_hash == "h2"
+        assert item.recommended_commits[0].confidence >= (
+            item.recommended_commits[1].confidence
+        )
+        commit_collection.query.assert_called_once()
+        assert commit_collection.query.call_args.kwargs["where"] == {"repository_id": 1}
 
     @pytest.mark.asyncio
     async def test_opposite_direction_candidate_is_not_matched(self):
@@ -181,7 +189,7 @@ class TestDecisionCommitMatchingService:
                     {
                         "commit_ref": "c1",
                         "commit_hash": "h1",
-                        "repository": "whylog/web",
+                        "repository_id": 1,
                         "direction_primary": "add",
                         "direction_multi_csv": "add",
                         "tech_keywords_csv": "redis",
@@ -208,8 +216,6 @@ class TestDecisionCommitMatchingService:
             )
 
         item = result.decisions[0]
-        assert item.decision_status == "UNAPPLIED"
-        assert item.connected_commits == []
         assert item.recommended_commits == []
 
     @pytest.mark.asyncio
@@ -257,7 +263,7 @@ class TestDecisionCommitMatchingService:
                         {
                             "commit_ref": "c-shared",
                             "commit_hash": "h-shared",
-                            "repository": "whylog/web",
+                            "repository_id": 1,
                             "direction_primary": "add",
                             "direction_multi_csv": "add",
                             "tech_keywords_csv": "redis,kafka,rabbitmq",
@@ -283,7 +289,7 @@ class TestDecisionCommitMatchingService:
                         {
                             "commit_ref": "c-shared",
                             "commit_hash": "h-shared",
-                            "repository": "whylog/web",
+                            "repository_id": 1,
                             "direction_primary": "add",
                             "direction_multi_csv": "add",
                             "tech_keywords_csv": "redis,kafka,rabbitmq",
@@ -312,10 +318,7 @@ class TestDecisionCommitMatchingService:
 
         first_item = result.decisions[0]
         second_item = result.decisions[1]
-        assert first_item.decision_status == "APPLIED"
-        assert len(first_item.connected_commits) == 1
-        assert second_item.decision_status == "UNAPPLIED"
-        assert second_item.connected_commits == []
+        assert len(first_item.recommended_commits) == 1
         assert second_item.recommended_commits == []
 
 
@@ -325,7 +328,7 @@ class TestDecisionCommitMatchingEndpoint:
     def test_match_endpoint_success(self):
         mock_result = DecisionCommitMatchResponse(
             meeting_id="meeting-123",
-            repository="whylog/web",
+            repository_id=1,
             total_decision_items=1,
             matched_decision_items=1,
             decisions=[],
@@ -382,7 +385,7 @@ class TestCommitAnalyzeHashMetadata:
         request = CommitAnalyzeRequest(
             commit_id=1,
             commit_hash="b8fd9ad",
-            repository="whylog/web",
+            repository_id=1,
             message="feat: API 구현",
             changed_file_list=[
                 ChangedFile(
@@ -403,6 +406,7 @@ class TestCommitAnalyzeHashMetadata:
         task = background_tasks.tasks[0]
         assert task.args[0] == 1
         assert task.args[1] == "b8fd9ad"
+        assert task.args[2] == 1
 
     @pytest.mark.asyncio
     async def test_generate_embedding_text_stores_commit_hash_metadata(self):
@@ -436,7 +440,7 @@ class TestCommitAnalyzeHashMetadata:
             await generate_embedding_text(
                 1,
                 "b8fd9ad",
-                "whylog/web",
+                1,
                 "feat: API 구현",
                 [
                     ChangedFile(
@@ -449,3 +453,5 @@ class TestCommitAnalyzeHashMetadata:
         _, kwargs = collection.upsert.call_args
         assert kwargs["metadatas"][0]["commit_id"] == 1
         assert kwargs["metadatas"][0]["commit_hash"] == "b8fd9ad"
+        assert kwargs["metadatas"][0]["commit_message"] == "feat: API 구현"
+        assert kwargs["metadatas"][0]["repository_id"] == 1

--- a/tests/test_decision_commit_matching.py
+++ b/tests/test_decision_commit_matching.py
@@ -23,7 +23,6 @@ from app.main import app
 def _build_match_payload() -> dict:
     return {
         "meeting_id": "meeting-123",
-        "project_id": "project-abc",
         "repository": "whylog/web",
         "top_k": 5,
     }
@@ -326,7 +325,6 @@ class TestDecisionCommitMatchingEndpoint:
     def test_match_endpoint_success(self):
         mock_result = DecisionCommitMatchResponse(
             meeting_id="meeting-123",
-            project_id="project-abc",
             repository="whylog/web",
             total_decision_items=1,
             matched_decision_items=1,

--- a/tests/test_decision_commit_matching_scoring.py
+++ b/tests/test_decision_commit_matching_scoring.py
@@ -1,0 +1,229 @@
+from app.domains.decision.services.matching_scoring import (
+    ScoringInput,
+    build_connection_reason,
+    calculate_match_score,
+    extract_direction_labels_from_text,
+    extract_module_tokens,
+    extract_tech_keywords,
+    normalize_direction_labels,
+    score_context_match,
+    score_keyword_match,
+)
+
+
+def _make_payload(
+    *,
+    distance: float | None = 0.12,
+    decision_text: str = (
+        "Redis 도입으로 notification module 처리 지연을 줄이고 queue 안정성을 확보한다."
+    ),
+    commit_text: str = (
+        "introduce redis pubsub for notification queue and improve retry."
+    ),
+    commit_message: str = "feat: introduce redis pubsub for notification queue",
+    decision_direction: set[str] | None = None,
+    commit_direction: set[str] | None = None,
+    decision_keywords: set[str] | None = None,
+    commit_keywords: set[str] | None = None,
+    decision_modules: set[str] | None = None,
+    commit_modules: set[str] | None = None,
+) -> ScoringInput:
+    resolved_decision_direction = (
+        decision_direction
+        if decision_direction is not None
+        else extract_direction_labels_from_text(decision_text)
+    )
+    resolved_commit_direction = (
+        commit_direction
+        if commit_direction is not None
+        else normalize_direction_labels("introduce")
+        | extract_direction_labels_from_text(commit_text)
+    )
+    resolved_decision_keywords = (
+        decision_keywords
+        if decision_keywords is not None
+        else extract_tech_keywords(decision_text)
+    )
+    resolved_commit_keywords = (
+        commit_keywords
+        if commit_keywords is not None
+        else extract_tech_keywords(commit_text, "redis")
+    )
+    resolved_decision_modules = (
+        decision_modules
+        if decision_modules is not None
+        else extract_module_tokens(decision_text)
+    )
+    resolved_commit_modules = (
+        commit_modules
+        if commit_modules is not None
+        else extract_module_tokens(commit_text, "notification,queue")
+    )
+
+    return ScoringInput(
+        semantic_distance=distance,
+        decision_text=decision_text,
+        commit_text=commit_text,
+        commit_message=commit_message,
+        decision_direction_labels=resolved_decision_direction,
+        commit_direction_labels=resolved_commit_direction,
+        decision_keywords=resolved_decision_keywords,
+        commit_keywords=resolved_commit_keywords,
+        decision_modules=resolved_decision_modules,
+        commit_modules=resolved_commit_modules,
+    )
+
+
+class TestKeywordScorePolicy:
+    def test_one_keyword_overlap_returns_15(self):
+        score = score_keyword_match({"redis"}, {"redis", "kafka"})
+        assert score == 15
+
+    def test_two_keyword_overlap_returns_25(self):
+        score = score_keyword_match({"redis", "kafka"}, {"redis", "kafka", "postgres"})
+        assert score == 25
+
+    def test_three_or_more_overlap_returns_30(self):
+        score = score_keyword_match(
+            {"redis", "kafka", "postgres"},
+            {"redis", "kafka", "postgres", "spring"},
+        )
+        assert score == 30
+
+
+class TestContextScorePolicy:
+    def test_same_domain_folder_returns_20(self):
+        score = score_context_match(
+            {"notification", "queue"},
+            {"notification", "queue", "producer"},
+        )
+        assert score == 20
+
+    def test_indirect_context_returns_10(self):
+        score = score_context_match({"notification"}, {"notificationservice"})
+        assert score == 10
+
+    def test_unrelated_context_returns_0(self):
+        score = score_context_match({"billing"}, {"auth", "token"})
+        assert score == 0
+
+
+class TestTotalScorePolicy:
+    def test_strong_match_becomes_applied(self):
+        score = calculate_match_score(_make_payload())
+
+        assert score.semantic >= 40
+        assert score.keyword >= 15
+        assert score.context >= 10
+        assert score.total >= 70
+        assert score.status == "APPLIED"
+
+    def test_boundary_score_70_is_applied(self):
+        payload = _make_payload(
+            distance=0.10,  # semantic 45
+            decision_keywords={"redis", "kafka"},
+            commit_keywords={"redis"},  # keyword 15
+            decision_modules={"notification"},
+            commit_modules={"notification"},  # context 10
+        )
+        score = calculate_match_score(payload)
+
+        assert score.total == 70
+        assert score.status == "APPLIED"
+
+    def test_boundary_score_69_is_partial(self):
+        payload = _make_payload(
+            distance=0.12,  # semantic 44
+            decision_keywords={"redis", "kafka"},
+            commit_keywords={"redis"},  # keyword 15
+            decision_modules={"notification"},
+            commit_modules={"notification"},  # context 10
+        )
+        score = calculate_match_score(payload)
+
+        assert score.total == 69
+        assert score.status == "PARTIAL"
+
+    def test_boundary_score_50_is_partial(self):
+        payload = _make_payload(
+            distance=0.30,  # semantic 35
+            decision_keywords={"redis", "kafka"},
+            commit_keywords={"redis"},  # keyword 15
+            decision_modules={"notification"},
+            commit_modules={"billing"},  # context 0
+        )
+        score = calculate_match_score(payload)
+
+        assert score.total == 50
+        assert score.status == "PARTIAL"
+
+    def test_boundary_score_49_is_unapplied(self):
+        payload = _make_payload(
+            distance=0.32,  # semantic 34
+            decision_keywords={"redis", "kafka"},
+            commit_keywords={"redis"},  # keyword 15
+            decision_modules={"notification"},
+            commit_modules={"billing"},  # context 0
+        )
+        score = calculate_match_score(payload)
+
+        assert score.total == 49
+        assert score.status == "UNAPPLIED"
+
+    def test_opposite_direction_sets_semantic_to_zero(self):
+        payload = _make_payload(
+            distance=0.05,  # semantic high expected, but must be zero
+            decision_direction={"positive"},
+            commit_direction={"negative"},
+        )
+        score = calculate_match_score(payload)
+
+        assert score.semantic == 0
+
+    def test_goal_mismatch_keyword_only_forces_zero(self):
+        payload = _make_payload(
+            distance=0.90,  # semantic 5
+            decision_keywords={"redis"},
+            commit_keywords={"redis"},  # keyword 15
+            decision_modules={"notification"},
+            commit_modules={"auth"},
+        )
+        score = calculate_match_score(payload)
+
+        assert score.is_goal_mismatch is True
+        assert score.total == 0
+        assert score.status == "UNAPPLIED"
+
+    def test_abstract_commit_message_penalty_minus_10(self):
+        payload = _make_payload(
+            distance=0.30,  # semantic 35
+            commit_message="refactor",
+            decision_keywords={"redis", "kafka"},
+            commit_keywords={"redis", "kafka"},  # keyword 25
+            decision_modules={"notification"},
+            commit_modules={"notification"},  # context 10
+        )
+        score = calculate_match_score(payload)
+
+        assert score.penalty >= 10
+        assert score.total <= 60
+
+    def test_ambiguous_decision_penalty_minus_10(self):
+        payload = _make_payload(
+            distance=0.20,  # semantic 40
+            decision_text="개선 방향 논의",
+            decision_keywords=set(),
+            decision_modules=set(),
+            commit_keywords={"redis", "kafka"},
+            commit_modules={"notification"},
+        )
+        score = calculate_match_score(payload)
+
+        assert score.penalty >= 10
+
+    def test_connection_reason_is_readable(self):
+        score = calculate_match_score(_make_payload())
+        reason = build_connection_reason(score)
+
+        assert reason.endswith(".")
+        assert len(reason) > 10


### PR DESCRIPTION
<!-- PR 제목 예시 -> [feat/#3] Deepgram 음성 전사 API 구현 -->

## ✨ 작업 개요
회의 결정사항 임베딩과 커밋 임베딩을 기반으로 커밋 추천/연결 결과를 반환하는 매칭 파이프라인을 구현했습니다.

현재 구현 기준은 기존 결정사항 임베딩 구조에 맞춘 `applied_item` 단위 매칭입니다.  

## 📄 작업 내용
- 결정사항-커밋 매칭 스코어링 정책 추가
  - semantic 50 / keyword 30 / context 20
  - 반대 방향 도입/제거 감지 시 semantic 0
  - 추상 커밋 메시지, 모호한 결정사항 보정 감점
  - 70 이상 APPLIED, 50~69 PARTIAL, 50 미만 UNAPPLIED

- 결정사항-커밋 매칭 서비스 추가
  - `meeting_id` 기준 decision embedding 조회
  - ChromaDB `commit_embeddings` 후보 조회
  - 정책 기반 재랭킹
  - `connected_commits` / `recommended_commits` 분리
  - 동일 커밋이 반대 방향 결정사항에 중복 연결되지 않도록 충돌 해소

- 매칭 API 추가
  - `POST /api/commit/match`
  - 결정사항별 APPLIED/PARTIAL 커밋 후보 반환
  - `score_breakdown`, `confidence`, `reason` 포함
  - 서비스 도메인에 없는 `project_id` 필드 제거

- 커밋 식별자 보강
  - `/api/commit/analyze` 요청에 `commit_hash` 선택 필드 추가
  - commit embedding metadata에 `commit_hash` 저장
  - match 응답에서 `commit_id`, `commit_hash` 반환
  - 커밋 메시지/날짜는 Spring 서버 commit DB에서 join하는 방향 권장

- 테스트 추가
  - 스코어링 정책 단위 테스트
  - 매칭 서비스 테스트
  - API 성공/검증 실패/서비스 실패 테스트
  - 실제 Chroma embedding 배열 처리 케이스 보강

- 커밋 매칭 응답을 추천 후보 중심으로 단순화했습니다.
  - `connected_commits` 제거
  - `decision_status` 제거
  - 커밋별 `status` 제거
  - 적용사항별 `recommended_commits`만 신뢰도 내림차순으로 반환
- Spring에서 관리하는 레포 기준에 맞춰 `repository` 문자열 대신 `repository_id`로 커밋 임베딩/매칭 필터를 수행하도록 변경했습니다.
- 추천 커밋 응답에 `commit_message`를 포함했습니다.
- 추천 사유(`reason`)를 점수 구성과 겹친 키워드/모듈 기준으로 구체화했습니다.

## 📌 관련 이슈
- close #14

## 🔌 API 변경사항 (해당 시)
### POST `/api/commit/match`

요청 예시:

```json
{
  "meeting_id": "1",
  "repository_id": 1,
  "top_k": 5
}
```
응답 예시: 
```json
{
  "meeting_id": "meeting-123",
  "repository": "whylog/web",
  "total_decision_items": 1,
  "matched_decision_items": 1,
  "decisions": [
    {
      "decision_document_id": "meeting-123_card0_item0",
      "decision_title": "Redis 캐시 도입",
      "applied_item": "세션 캐시 적용",
      "decision_status": "APPLIED",
      "connected_commits": [
        {
          "commit_id": 1,
          "commit_hash": "b8fd9ad",
          "repository": "whylog/web",
          "status": "APPLIED",
          "confidence": 82,
          "reason": "의미 유사성이 높습니다, 핵심 기술 키워드가 다수 일치합니다.",
          "score_breakdown": {
            "semantic": 42,
            "keyword": 30,
            "context": 10,
            "penalty": 0,
            "total": 82
          }
        }
      ],
      "recommended_commits": []
    }
  ]
}
```
### POST /api/commit/analyze
commit_hash 선택 필드가 추가되었습니다.
```json
{{
  "commit_id": 1,
  "commit_hash": "b8fd9ad",
  "repository_id": 1,
  "message": "feat: API 구현",
  "changed_file_list": []
}
```
### 실데이터 검증 요약
검증 흐름:

Spring 로그인
POST /api/repositories/1/sync
GET /api/repositories/1/commits
GET /api/repositories/1/commits/{commitHash}
Python /api/commit/analyze로 실제 커밋 상세 push
ChromaDB commit_embeddings 저장 확인
임의 회의 결정사항 embedding 저장
/api/commit/match 호출

검증 결과:

실제 repo 1 커밋 기반으로 APPLIED/PARTIAL 매칭 결과 반환 확인
commit_hash가 Chroma metadata 및 match 응답까지 유지되는 것 확인
commit_embeddings가 비어 있던 상태에서 실제 커밋 임베딩 저장 후 매칭 성공 확인

상세 내역은 노션에 정리 예정입니다.

## 💬 기타 사항
현재 Spring이 commit detail을 Python /api/commit/analyze로 자동 push하는 연동은 팀원 작업 범위입니다.
현 PR에서는 해당 연동이 완료되기 전에도 매칭 파이프라인을 검증할 수 있도록 실제 Spring 커밋 데이터를 수동으로 Python에 넣어 E2E를 확인했습니다.
추천 커밋 화면에서 필요한 commit message/date는 Spring commit DB에 이미 있으므로, Python match 응답의 commit_id 또는 commit_hash 기준으로 Spring에서 join하는 방식이 어떤지 의견 부탁드립니다.
응답은 적용사항별 recommended_commits만 반환하며, 실제 사용자 연결 상태는 Spring DB에서 관리합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 의사결정과 커밋을 자동으로 매칭하고 관련성을 분석하는 기능이 추가되었습니다
  * 커밋 분석 요청 시 커밋 해시 정보를 메타데이터로 저장할 수 있습니다

* **개선 사항**
  * 의사결정 및 커밋 매칭 점수 계산 로직이 향상되어 더욱 정확한 매칭 결과를 제공합니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->