### PR TITLE
[feat/#22] 커밋 분석 비동기 실행 및 임베딩 완료 상태 조회 추가

### DIFF
--- a/app/domains/commit/router.py
+++ b/app/domains/commit/router.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, BackgroundTasks
+from fastapi import APIRouter, BackgroundTasks, HTTPException
 
 from app.core.errors import AppServiceError
 from app.core.responses import ApiErrorResponse, ApiResponse, ok_response
@@ -7,6 +7,15 @@ from app.domains.commit.schemas import (
     ApplicationCommitMatchResponse,
     CommitAnalyzeRequest,
     CommitAnalyzeResponse,
+    CommitAnalyzeRunAccepted,
+    CommitAnalyzeRunStatus,
+)
+from app.domains.commit.services.analyze_runs import (
+    create_commit_analyze_run as create_commit_analyze_run_record,
+)
+from app.domains.commit.services.analyze_runs import (
+    get_commit_analyze_run_status,
+    run_commit_analyze_pipeline,
 )
 from app.domains.commit.services.diff_filter import filter_changed_files
 from app.domains.commit.services.matching import match_applications_with_commits
@@ -16,6 +25,21 @@ from app.domains.commit.services.summarize import (
 )
 
 router = APIRouter(prefix="/commit", tags=["commit"])
+
+COMMIT_ANALYZE_ASYNC_GUIDE = (
+    "Spring 연동 가이드:\n"
+    "1) 레포지토리 커밋 동기화 시 커밋별로 "
+    "POST /api/commit/analyze/runs를 호출합니다.\n"
+    "2) 응답의 run_id로 GET /api/commit/analyze/runs/{run_id}를 폴링합니다.\n"
+    "3) phase=summary_ready부터 커밋 요약을 확인할 수 있습니다.\n"
+    "4) status=completed && phase=embedding_ready 확인 후 "
+    "POST /api/commit/match를 호출합니다.\n"
+    "5) embedding_ready 전에는 방금 분석한 커밋이 추천 후보에 "
+    "아직 반영되지 않았을 수 있습니다.\n"
+    "6) status=failed 시 error를 기록하고 필요 시 재시도합니다.\n"
+    "7) run 조회 404는 만료/정리/재기동 유실 가능성이 있으므로 "
+    "재요청 정책을 둡니다."
+)
 
 
 # POST /api/commit/analyze — Spring에서 커밋 데이터를 받아 LLM 요약 후 반환
@@ -97,6 +121,131 @@ async def analyze_commit(
     )
     return ok_response(
         CommitAnalyzeResponse(commit_id=request.commit_id, summary=summary)
+    )
+
+
+@router.post(
+    "/analyze/runs",
+    response_model=ApiResponse[CommitAnalyzeRunAccepted],
+    status_code=202,
+    summary="커밋 분석 비동기 실행 생성",
+    description=(
+        "커밋 요약과 임베딩 저장을 백그라운드 run으로 실행합니다. "
+        "즉시 run_id를 반환하며, 상태는 "
+        "GET /api/commit/analyze/runs/{run_id}로 조회합니다.\n\n"
+        "기존 /api/commit/analyze는 즉시 요약 응답 후 임베딩을 "
+        "BackgroundTasks로 저장하므로, 안정적인 매칭 플로우에서는 "
+        "이 비동기 run API 사용을 권장합니다.\n\n"
+        f"{COMMIT_ANALYZE_ASYNC_GUIDE}"
+    ),
+    responses={
+        202: {
+            "description": "커밋 분석 비동기 작업이 접수되었습니다.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "isSuccess": True,
+                        "code": "COMMIT_ANALYZE_202",
+                        "message": "커밋 분석 비동기 실행이 접수되었습니다.",
+                        "result": {
+                            "run_id": "550e8400e29b41d4a716446655440000",
+                            "status": "queued",
+                            "phase": "queued",
+                            "commit_id": 4,
+                            "commit_hash": ("cb2222fb915f9dfbd5b22eded57dadd57f225798"),
+                            "repository_id": 1,
+                        },
+                    }
+                }
+            },
+        },
+        422: {
+            "model": ApiErrorResponse,
+            "description": "요청 스키마 검증 실패(예: message 누락, 빈 파일 목록).",
+        },
+    },
+)
+async def create_commit_analyze_run(
+    request: CommitAnalyzeRequest,
+    background_tasks: BackgroundTasks,
+) -> ApiResponse[CommitAnalyzeRunAccepted]:
+    accepted = await create_commit_analyze_run_record(request)
+    background_tasks.add_task(run_commit_analyze_pipeline, accepted.run_id)
+    return ok_response(
+        accepted,
+        code="COMMIT_ANALYZE_202",
+        message="커밋 분석 비동기 실행이 접수되었습니다.",
+    )
+
+
+@router.get(
+    "/analyze/runs/{run_id}",
+    response_model=ApiResponse[CommitAnalyzeRunStatus],
+    summary="커밋 분석 비동기 실행 상태 조회",
+    description=(
+        "run_id 기준으로 커밋 분석 상태를 조회합니다. "
+        "phase 값은 queued/summarizing/summary_ready/embedding/"
+        "embedding_ready/failed 중 하나입니다.\n\n"
+        "Spring 처리 규칙:\n"
+        "- phase=summary_ready: 커밋 summary 사용 가능\n"
+        "- phase=embedding: ChromaDB 저장 진행 중\n"
+        "- status=completed, phase=embedding_ready: /api/commit/match 호출 권장\n"
+        "- status=failed: error 기준으로 재시도/장애 처리\n\n"
+        f"{COMMIT_ANALYZE_ASYNC_GUIDE}"
+    ),
+    responses={
+        200: {
+            "description": "현재 커밋 분석 실행 상태 또는 중간/최종 결과.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "isSuccess": True,
+                        "code": "COMMIT_ANALYZE_200",
+                        "message": "커밋 분석 비동기 실행 상태 조회에 성공했습니다.",
+                        "result": {
+                            "run_id": "550e8400e29b41d4a716446655440000",
+                            "status": "completed",
+                            "phase": "embedding_ready",
+                            "commit_id": 4,
+                            "commit_hash": ("cb2222fb915f9dfbd5b22eded57dadd57f225798"),
+                            "repository_id": 1,
+                            "submitted_at": "2026-04-27T09:00:00Z",
+                            "started_at": "2026-04-27T09:00:01Z",
+                            "finished_at": "2026-04-27T09:00:10Z",
+                            "error": None,
+                            "result": {
+                                "commit_id": 4,
+                                "commit_hash": (
+                                    "cb2222fb915f9dfbd5b22eded57dadd57f225798"
+                                ),
+                                "repository_id": 1,
+                                "summary": (
+                                    "Swagger 에러 문서화를 위한 "
+                                    "ApiErrorCodeExample 어노테이션을 추가했습니다."
+                                ),
+                                "embedding_ready": True,
+                            },
+                        },
+                    }
+                }
+            },
+        },
+        404: {
+            "model": ApiErrorResponse,
+            "description": "해당 run_id를 찾을 수 없습니다(만료/정리 포함).",
+        },
+    },
+)
+async def get_commit_analyze_run(
+    run_id: str,
+) -> ApiResponse[CommitAnalyzeRunStatus]:
+    status = await get_commit_analyze_run_status(run_id)
+    if not status:
+        raise HTTPException(status_code=404, detail="해당 실행을 찾을 수 없습니다.")
+    return ok_response(
+        status,
+        code="COMMIT_ANALYZE_200",
+        message="커밋 분석 비동기 실행 상태 조회에 성공했습니다.",
     )
 
 

--- a/app/domains/commit/schemas.py
+++ b/app/domains/commit/schemas.py
@@ -1,4 +1,16 @@
+from typing import Literal
+
 from pydantic import BaseModel, Field
+
+CommitAnalyzeRunStatusValue = Literal["queued", "processing", "completed", "failed"]
+CommitAnalyzeRunPhase = Literal[
+    "queued",
+    "summarizing",
+    "summary_ready",
+    "embedding",
+    "embedding_ready",
+    "failed",
+]
 
 
 class ChangedFile(BaseModel):
@@ -23,6 +35,60 @@ class CommitAnalyzeRequest(BaseModel):
 class CommitAnalyzeResponse(BaseModel):
     commit_id: int = Field(description="커밋 ID")
     summary: str = Field(description="커밋 요약")
+
+
+class CommitAnalyzeRunResult(BaseModel):
+    commit_id: int = Field(description="커밋 ID")
+    commit_hash: str | None = Field(default=None, description="커밋 해시")
+    repository_id: int = Field(description="Spring 레포지토리 ID")
+    summary: str = Field(description="커밋 요약")
+    embedding_ready: bool = Field(description="커밋 임베딩 저장 완료 여부")
+
+
+class CommitAnalyzeRunAccepted(BaseModel):
+    run_id: str = Field(description="비동기 실행 식별자")
+    status: CommitAnalyzeRunStatusValue = Field(
+        description='실행 상태("queued" 고정으로 시작)'
+    )
+    phase: CommitAnalyzeRunPhase = Field(
+        description='실행 단계("queued" 고정으로 시작)'
+    )
+    commit_id: int = Field(description="커밋 ID")
+    commit_hash: str | None = Field(default=None, description="커밋 해시")
+    repository_id: int = Field(description="Spring 레포지토리 ID")
+
+
+class CommitAnalyzeRunStatus(BaseModel):
+    run_id: str = Field(description="비동기 실행 식별자")
+    status: CommitAnalyzeRunStatusValue = Field(
+        description="queued/processing/completed/failed"
+    )
+    phase: CommitAnalyzeRunPhase = Field(
+        description=(
+            "queued/summarizing/summary_ready/embedding/embedding_ready/failed. "
+            "embedding_ready(completed) 이후 /api/commit/match 호출을 권장합니다."
+        )
+    )
+    commit_id: int = Field(description="커밋 ID")
+    commit_hash: str | None = Field(default=None, description="커밋 해시")
+    repository_id: int = Field(description="Spring 레포지토리 ID")
+    submitted_at: str = Field(description="실행 접수 시각(UTC ISO8601)")
+    started_at: str | None = Field(
+        default=None,
+        description="실행 시작 시각(UTC ISO8601)",
+    )
+    finished_at: str | None = Field(
+        default=None,
+        description="실행 종료 시각(UTC ISO8601)",
+    )
+    error: str | None = Field(default=None, description="실패 시 오류 메시지")
+    result: CommitAnalyzeRunResult | None = Field(
+        default=None,
+        description=(
+            "중간/최종 결과. summary_ready부터 summary가 포함되고, "
+            "embedding_ready에서 embedding_ready=true가 됩니다."
+        ),
+    )
 
 
 class MatchScoreBreakdown(BaseModel):

--- a/app/domains/commit/services/analyze_runs.py
+++ b/app/domains/commit/services/analyze_runs.py
@@ -1,0 +1,243 @@
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+from app.core.errors import AppServiceError
+from app.domains.commit.schemas import (
+    CommitAnalyzeRequest,
+    CommitAnalyzeRunAccepted,
+    CommitAnalyzeRunPhase,
+    CommitAnalyzeRunResult,
+    CommitAnalyzeRunStatus,
+    CommitAnalyzeRunStatusValue,
+)
+from app.domains.commit.services.diff_filter import filter_changed_files
+from app.domains.commit.services.summarize import (
+    store_commit_embedding,
+    summarize_commit,
+)
+
+RUN_TTL = timedelta(hours=24)
+MAX_RUN_RECORDS = 300
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _CommitAnalyzeRunRecord:
+    run_id: str
+    status: CommitAnalyzeRunStatusValue
+    phase: CommitAnalyzeRunPhase
+    request: CommitAnalyzeRequest
+    submitted_at: datetime
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    error: str | None = None
+    result: CommitAnalyzeRunResult | None = None
+
+
+_runs: dict[str, _CommitAnalyzeRunRecord] = {}
+_lock = asyncio.Lock()
+
+
+def _utc_now() -> datetime:
+    # UTC 기준 현재 시각 반환
+    return datetime.now(UTC)
+
+
+def _to_iso(value: datetime | None) -> str | None:
+    # datetime을 ISO8601 문자열로 변환
+    return value.isoformat() if value else None
+
+
+def _cleanup_runs_locked() -> None:
+    # TTL/최대 개수 정책에 따라 run 저장소를 정리
+    now = _utc_now()
+    expiry_cutoff = now - RUN_TTL
+
+    expired_ids = []
+    for run_id, run in _runs.items():
+        # 진행 중 실행은 TTL 삭제 대상에서 제외
+        if run.status in {"queued", "processing"}:
+            continue
+        reference_time = run.finished_at or run.submitted_at
+        if reference_time < expiry_cutoff:
+            expired_ids.append(run_id)
+    for run_id in expired_ids:
+        _runs.pop(run_id, None)
+
+    if len(_runs) <= MAX_RUN_RECORDS:
+        return
+
+    overflow = len(_runs) - MAX_RUN_RECORDS
+    eviction_candidates = sorted(
+        (
+            item
+            for item in _runs.items()
+            if item[1].status not in {"queued", "processing"}
+        ),
+        key=lambda item: item[1].submitted_at,
+    )
+    for run_id, _ in eviction_candidates[:overflow]:
+        _runs.pop(run_id, None)
+
+
+def _to_run_status(run: _CommitAnalyzeRunRecord) -> CommitAnalyzeRunStatus:
+    # 내부 저장 레코드를 외부 응답 모델로 변환
+    return CommitAnalyzeRunStatus(
+        run_id=run.run_id,
+        status=run.status,
+        phase=run.phase,
+        commit_id=run.request.commit_id,
+        commit_hash=run.request.commit_hash,
+        repository_id=run.request.repository_id,
+        submitted_at=run.submitted_at.isoformat(),
+        started_at=_to_iso(run.started_at),
+        finished_at=_to_iso(run.finished_at),
+        error=run.error,
+        result=run.result.model_copy(deep=True) if run.result else None,
+    )
+
+
+async def create_commit_analyze_run(
+    request: CommitAnalyzeRequest,
+) -> CommitAnalyzeRunAccepted:
+    # 커밋 분석 비동기 실행 레코드를 생성
+    async with _lock:
+        _cleanup_runs_locked()
+        run_id = uuid4().hex
+        _runs[run_id] = _CommitAnalyzeRunRecord(
+            run_id=run_id,
+            status="queued",
+            phase="queued",
+            request=request.model_copy(deep=True),
+            submitted_at=_utc_now(),
+        )
+        return CommitAnalyzeRunAccepted(
+            run_id=run_id,
+            status="queued",
+            phase="queued",
+            commit_id=request.commit_id,
+            commit_hash=request.commit_hash,
+            repository_id=request.repository_id,
+        )
+
+
+async def _mark_run_processing(run_id: str) -> None:
+    # run 상태를 처리중(summarizing)으로 전환
+    async with _lock:
+        run = _runs.get(run_id)
+        if not run:
+            return
+        run.status = "processing"
+        run.phase = "summarizing"
+        run.started_at = _utc_now()
+        run.error = None
+
+
+async def _mark_run_phase(
+    run_id: str,
+    phase: CommitAnalyzeRunPhase,
+    result: CommitAnalyzeRunResult | None = None,
+) -> None:
+    # 단계별 중간 결과를 저장하며 phase 갱신
+    async with _lock:
+        run = _runs.get(run_id)
+        if not run:
+            return
+        run.phase = phase
+        if result is not None:
+            run.result = result.model_copy(deep=True)
+
+
+async def _mark_run_completed(run_id: str, result: CommitAnalyzeRunResult) -> None:
+    # run을 최종 완료 상태로 전환
+    async with _lock:
+        run = _runs.get(run_id)
+        if not run:
+            return
+        run.status = "completed"
+        run.phase = "embedding_ready"
+        run.result = result.model_copy(deep=True)
+        run.error = None
+        run.finished_at = _utc_now()
+
+
+async def _mark_run_failed(run_id: str, error: str) -> None:
+    # run을 실패 상태로 전환하고 오류 메시지 저장
+    async with _lock:
+        run = _runs.get(run_id)
+        if not run:
+            return
+        run.status = "failed"
+        run.phase = "failed"
+        run.error = error
+        run.finished_at = _utc_now()
+
+
+async def get_commit_analyze_run_status(
+    run_id: str,
+) -> CommitAnalyzeRunStatus | None:
+    # run 현재 상태/결과를 조회
+    async with _lock:
+        _cleanup_runs_locked()
+        run = _runs.get(run_id)
+        if not run:
+            return None
+        return _to_run_status(run)
+
+
+async def run_commit_analyze_pipeline(run_id: str) -> None:
+    # 커밋 요약부터 임베딩 저장까지 단계별(phase)로 실행
+    async with _lock:
+        run = _runs.get(run_id)
+        if not run:
+            return
+        request = run.request.model_copy(deep=True)
+
+    try:
+        filtered_files = filter_changed_files(request.changed_file_list)
+        if not filtered_files:
+            raise AppServiceError(
+                "분석할 수 있는 변경 파일이 없습니다.", status_code=400
+            )
+
+        await _mark_run_processing(run_id)
+        summary = await summarize_commit(request.message, filtered_files)
+        result = CommitAnalyzeRunResult(
+            commit_id=request.commit_id,
+            commit_hash=request.commit_hash,
+            repository_id=request.repository_id,
+            summary=summary,
+            embedding_ready=False,
+        )
+        await _mark_run_phase(
+            run_id=run_id,
+            phase="summary_ready",
+            result=result,
+        )
+
+        await _mark_run_phase(
+            run_id=run_id,
+            phase="embedding",
+            result=result,
+        )
+        await store_commit_embedding(
+            commit_id=request.commit_id,
+            commit_hash=request.commit_hash,
+            repository_id=request.repository_id,
+            message=request.message,
+            changed_file_list=filtered_files,
+        )
+
+        completed_result = result.model_copy(update={"embedding_ready": True})
+        await _mark_run_completed(run_id, completed_result)
+    except AppServiceError as e:
+        await _mark_run_failed(run_id, f"{e.status_code}: {e.message}")
+    except Exception as e:
+        logger.exception(
+            "commit analyze run failed",
+            extra={"run_id": run_id},
+        )
+        await _mark_run_failed(run_id, f"unexpected_error: {e}")

--- a/app/domains/commit/services/summarize.py
+++ b/app/domains/commit/services/summarize.py
@@ -216,6 +216,59 @@ async def summarize_commit(
         ) from e
 
 
+async def store_commit_embedding(
+    commit_id: int,
+    commit_hash: str | None,
+    repository_id: int,
+    message: str,
+    changed_file_list: list[ChangedFile],
+) -> None:
+    """커밋 임베딩용 구조화 텍스트를 생성하고 ChromaDB에 저장한다."""
+    client = _get_client()
+    commit_input = _build_commit_input(message, changed_file_list)
+
+    # 1) LLM으로 구조화 텍스트 생성
+    raw_text = await _call_gemini(client, EMBEDDING_PROMPT, commit_input, timeout=60.0)
+    parsed = _parse_embedding_response(raw_text)
+
+    # 2) 스펙에 맞는 임베딩용 텍스트 조합
+    commit_subject = message.split("\n", 1)[0].strip()
+    title = f"repository-{repository_id} {commit_subject}"
+    text_parts = [f"변경요약: {parsed.summary}"]
+    if parsed.tech_keywords:
+        text_parts.append(f"기술키워드: {','.join(parsed.tech_keywords)}")
+    if parsed.directions:
+        text_parts.append(f"변경방향: {','.join(parsed.directions)}")
+    if parsed.module_tags:
+        text_parts.append(f"파일맥락: {','.join(parsed.module_tags)}")
+    embedding_text = f"title: {title} | text: {' | '.join(text_parts)}"
+
+    # 3) 임베딩 벡터 생성
+    embedding = await _generate_embedding(embedding_text)
+
+    # 4) ChromaDB 저장
+    collection = get_commit_collection()
+    doc_id = f"commit_{commit_id}"
+    metadata = {
+        "commit_id": commit_id,
+        "commit_message": commit_subject,
+        "repository_id": repository_id,
+        "direction": ",".join(parsed.directions),
+        "tech_keywords_csv": ",".join(parsed.tech_keywords),
+        "module_tags_csv": ",".join(parsed.module_tags),
+    }
+    if commit_hash:
+        metadata["commit_hash"] = commit_hash
+    await asyncio.to_thread(
+        collection.upsert,
+        ids=[doc_id],
+        documents=[embedding_text],
+        embeddings=[embedding],
+        metadatas=[metadata],
+    )
+    logger.info("커밋 %d 임베딩 저장 완료: %s", commit_id, doc_id)
+
+
 async def generate_embedding_text(
     commit_id: int,
     commit_hash: str | None,
@@ -225,50 +278,12 @@ async def generate_embedding_text(
 ) -> None:
     """백그라운드에서 임베딩용 구조화 텍스트 생성. 응답을 블로킹하지 않음."""
     try:
-        client = _get_client()
-        commit_input = _build_commit_input(message, changed_file_list)
-
-        # 1) LLM으로 구조화 텍스트 생성
-        raw_text = await _call_gemini(
-            client, EMBEDDING_PROMPT, commit_input, timeout=60.0
+        await store_commit_embedding(
+            commit_id=commit_id,
+            commit_hash=commit_hash,
+            repository_id=repository_id,
+            message=message,
+            changed_file_list=changed_file_list,
         )
-        parsed = _parse_embedding_response(raw_text)
-
-        # 2) 스펙에 맞는 임베딩용 텍스트 조합
-        commit_subject = message.split("\n", 1)[0].strip()
-        title = f"repository-{repository_id} {commit_subject}"
-        text_parts = [f"변경요약: {parsed.summary}"]
-        if parsed.tech_keywords:
-            text_parts.append(f"기술키워드: {','.join(parsed.tech_keywords)}")
-        if parsed.directions:
-            text_parts.append(f"변경방향: {','.join(parsed.directions)}")
-        if parsed.module_tags:
-            text_parts.append(f"파일맥락: {','.join(parsed.module_tags)}")
-        embedding_text = f"title: {title} | text: {' | '.join(text_parts)}"
-
-        # 3) 임베딩 벡터 생성
-        embedding = await _generate_embedding(embedding_text)
-
-        # 4) ChromaDB 저장
-        collection = get_commit_collection()
-        doc_id = f"commit_{commit_id}"
-        metadata = {
-            "commit_id": commit_id,
-            "commit_message": commit_subject,
-            "repository_id": repository_id,
-            "direction": ",".join(parsed.directions),
-            "tech_keywords_csv": ",".join(parsed.tech_keywords),
-            "module_tags_csv": ",".join(parsed.module_tags),
-        }
-        if commit_hash:
-            metadata["commit_hash"] = commit_hash
-        await asyncio.to_thread(
-            collection.upsert,
-            ids=[doc_id],
-            documents=[embedding_text],
-            embeddings=[embedding],
-            metadatas=[metadata],
-        )
-        logger.info("커밋 %d 임베딩 저장 완료: %s", commit_id, doc_id)
     except Exception:
         logger.exception("커밋 %d 임베딩 텍스트 생성 실패", commit_id)

--- a/tests/test_commit_analyze_runs.py
+++ b/tests/test_commit_analyze_runs.py
@@ -1,0 +1,124 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.domains.commit.schemas import ChangedFile, CommitAnalyzeRequest
+from app.domains.commit.services import analyze_runs
+from app.domains.commit.services.analyze_runs import (
+    create_commit_analyze_run,
+    get_commit_analyze_run_status,
+    run_commit_analyze_pipeline,
+)
+from app.main import app
+
+
+def _build_analyze_payload() -> dict:
+    return {
+        "commit_id": 4,
+        "commit_hash": "cb2222fb915f9dfbd5b22eded57dadd57f225798",
+        "repository_id": 1,
+        "message": "chore: Swagger 에러 문서화를 위한 어노테이션 추가",
+        "changed_file_list": [
+            {
+                "file_name": "src/main/java/com/whylog/ApiErrorCodeExample.java",
+                "changed_code": "+public @interface ApiErrorCodeExample {}",
+            }
+        ],
+    }
+
+
+@pytest.fixture(autouse=True)
+def clear_commit_analyze_runs():
+    analyze_runs._runs.clear()
+    yield
+    analyze_runs._runs.clear()
+
+
+class TestCommitAnalyzeRunsEndpoint:
+    client = TestClient(app)
+
+    def test_create_commit_analyze_run_returns_accepted(self):
+        with patch(
+            "app.domains.commit.router.run_commit_analyze_pipeline",
+            new_callable=AsyncMock,
+        ):
+            response = self.client.post(
+                "/api/commit/analyze/runs",
+                json=_build_analyze_payload(),
+            )
+
+        assert response.status_code == 202
+        body = response.json()
+        assert body["isSuccess"] is True
+        assert body["code"] == "COMMIT_ANALYZE_202"
+        assert body["result"]["status"] == "queued"
+        assert body["result"]["phase"] == "queued"
+        assert body["result"]["commit_id"] == 4
+        assert body["result"]["repository_id"] == 1
+
+    def test_get_missing_commit_analyze_run_returns_404(self):
+        response = self.client.get("/api/commit/analyze/runs/not-found")
+
+        assert response.status_code == 404
+        body = response.json()
+        assert body["isSuccess"] is False
+        assert body["code"] == "COMMON_404"
+
+
+class TestCommitAnalyzeRunService:
+    @pytest.mark.asyncio
+    async def test_run_pipeline_completes_after_embedding_saved(self):
+        request = CommitAnalyzeRequest(
+            **_build_analyze_payload(),
+        )
+        accepted = await create_commit_analyze_run(request)
+
+        with (
+            patch(
+                "app.domains.commit.services.analyze_runs.summarize_commit",
+                new_callable=AsyncMock,
+                return_value="Swagger 에러 응답 예시 문서화를 보강했습니다.",
+            ) as summarize_mock,
+            patch(
+                "app.domains.commit.services.analyze_runs.store_commit_embedding",
+                new_callable=AsyncMock,
+            ) as embedding_mock,
+        ):
+            await run_commit_analyze_pipeline(accepted.run_id)
+
+        status = await get_commit_analyze_run_status(accepted.run_id)
+
+        assert status is not None
+        assert status.status == "completed"
+        assert status.phase == "embedding_ready"
+        assert status.result is not None
+        assert status.result.summary == "Swagger 에러 응답 예시 문서화를 보강했습니다."
+        assert status.result.embedding_ready is True
+        summarize_mock.assert_awaited_once()
+        embedding_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_run_pipeline_fails_when_all_files_are_filtered(self):
+        request = CommitAnalyzeRequest(
+            commit_id=5,
+            commit_hash="b8fd9ad",
+            repository_id=1,
+            message="chore: lock 파일 갱신",
+            changed_file_list=[
+                ChangedFile(
+                    file_name="package-lock.json",
+                    changed_code="+{}",
+                )
+            ],
+        )
+        accepted = await create_commit_analyze_run(request)
+
+        await run_commit_analyze_pipeline(accepted.run_id)
+
+        status = await get_commit_analyze_run_status(accepted.run_id)
+
+        assert status is not None
+        assert status.status == "failed"
+        assert status.phase == "failed"
+        assert status.error == "400: 분석할 수 있는 변경 파일이 없습니다."


### PR DESCRIPTION
<!-- PR 제목 예시 -> [feat/#3] Deepgram 음성 전사 API 구현 -->

## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->
커밋 분석 후 임베딩 저장이 완료되기 전에 `/api/commit/match`가 호출되면 새 커밋이 추천 후보에서 누락될 수 있는 문제를 해결했습니다.
커밋 분석도 회의 분석과 동일하게 `run_id` 기반 비동기 실행/폴링 구조로 확장하여, Spring이 `embedding_ready` 상태를 확인한 뒤 매칭을 호출할 수 있도록 했습니다.

## 📄 작업 내용
- 커밋 분석 비동기 run DTO 추가
  - `CommitAnalyzeRunAccepted`
  - `CommitAnalyzeRunStatus`
  - `CommitAnalyzeRunResult`
- 커밋 분석 run phase 추가
  - `queued`
  - `summarizing`
  - `summary_ready`
  - `embedding`
  - `embedding_ready`
  - `failed`
- 커밋 분석 run 인메모리 저장소 및 상태 전환 서비스 추가
- 신규 API 추가
  - `POST /api/commit/analyze/runs`
  - `GET /api/commit/analyze/runs/{run_id}`
- 기존 커밋 임베딩 저장 로직을 `store_commit_embedding()`으로 분리
  - run 파이프라인에서는 임베딩 저장 완료 시점을 직접 확인
  - 기존 `/api/commit/analyze`는 그대로 유지
- Swagger 설명에 Spring 연동 플로우 추가
- 커밋 분석 run 성공/실패/조회 테스트 추가
## 📌 관련 이슈
- close #22 

## 🔌 API 변경사항 (해당 시)
<!-- 새로운 엔드포인트 추가 또는 기존 변경이 있다면 적어주세요. -->
#### `POST /api/commit/analyze/runs`
커밋 분석 비동기 실행을 생성합니다.
요청 body는 기존 `/api/commit/analyze`와 동일합니다.

#### GET /api/commit/analyze/runs/{run_id}
커밋 분석 비동기 실행 상태를 조회합니다.

## 💬 기타 사항
<!-- 리뷰어가 알면 좋을 내용이 있다면 적어주세요 -->
POST /api/commit/analyze는 기존 호환을 위해 유지했습니다.
다만 안정적인 매칭 플로우에서는 /api/commit/analyze/runs 사용을 권장합니다.
run 상태를 조회하는 저장소가 임시 메모리라서 운영 환경에서 주의가 필요할 것 같습니다!(파이썬 서버 재시작시 등)
#### 권장 호출 순서
1. 레포지토리 커밋 동기화
2. 커밋별 POST /api/commit/analyze/runs 호출
3. run_id 저장
4. GET /api/commit/analyze/runs/{run_id} 폴링
5. status=completed && phase=embedding_ready 확인
6. POST /api/commit/match 호출

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **비동기 커밋 분석 워크플로우 추가** - 커밋 분석 요청을 백그라운드에서 처리하며, 요청 생성 시 HTTP 202 응답과 run_id를 받아 나중에 분석 상태를 조회할 수 있습니다.
* 기존의 동기식 분석 엔드포인트는 그대로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->