### PR TITLE
[feat/#29] 실시간 회의 발화 로그 기반 STT 화자 이름 매핑

### DIFF
--- a/app/domains/transcribe/router.py
+++ b/app/domains/transcribe/router.py
@@ -33,15 +33,52 @@ from app.domains.pipeline.services.analysis_runs import (
     mark_run_phase,
     mark_run_processing,
 )
-from app.domains.transcribe.schemas import TranscribeSegment
+from app.domains.transcribe.schemas import LiveTranscriptMessage, TranscribeSegment
 from app.domains.transcribe.services import deepgram, transcript_correction
 from app.domains.transcribe.services.deepgram import CONTENT_TYPE_MAP
+from app.domains.transcribe.services.live_transcript_merge import (
+    merge_live_transcript,
+    parse_live_messages,
+)
 
 router = APIRouter(prefix="/transcribe", tags=["transcribe"])
 MAX_FILE_SIZE = 100 * 1024 * 1024
 logger = logging.getLogger(__name__)
 AUDIO_FILE_DESCRIPTION = (
     "회의 녹음 파일. 지원 포맷: wav/mp3/m4a/aac/flac/ogg/webm, 최대 100MB."
+)
+LIVE_MESSAGES_GUIDE = (
+    "실시간 발화 로그 연동:\n"
+    "- live_messages는 Spring WebSocket TEXT 발화 로그 JSON 배열 문자열입니다.\n"
+    "- 각 항목은 type, meetingId, fromMemberId, fromName, "
+    "timestamp, text를 포함합니다.\n"
+    "- FastAPI는 Deepgram STT 결과와 live_messages를 "
+    "시간/순서/텍스트 유사도로 매칭합니다.\n"
+    "- 매칭 성공 시 transcript_segments[].speaker는 실제 이름으로 보강되고 "
+    "member_id가 함께 반환됩니다.\n"
+    "- 매칭 신뢰도가 충분하면 transcript_segments[].text도 "
+    "WebSocket text 기준으로 보정합니다.\n"
+    "- 매칭 실패 시 기존 Speaker N/STT text를 유지합니다."
+)
+LIVE_MESSAGES_FIELD_DESCRIPTION = (
+    "WebSocket 실시간 발화 로그 JSON 배열 문자열(선택). "
+    "Spring WebSocket TEXT 메시지를 아래 형식 그대로 배열로 전달합니다.\n\n"
+    "예시:\n"
+    "[\n"
+    "  {\n"
+    '    "type": "TEXT",\n'
+    '    "meetingId": 123,\n'
+    '    "fromMemberId": 1,\n'
+    '    "fromName": "김준용",\n'
+    '    "timestamp": "00:01:48",\n'
+    '    "targetMemberId": 2,\n'
+    '    "text": "안녕하세요",\n'
+    '    "payload": {}\n'
+    "  }\n"
+    "]\n\n"
+    "필수 사용 필드: type, meetingId, fromMemberId, fromName, timestamp, text. "
+    "targetMemberId와 payload는 선택입니다. "
+    'timestamp는 가능하면 "00:01:48"처럼 회의 기준 발화 시작 시간으로 전달하세요.'
 )
 SPRING_ASYNC_GUIDE = (
     "Spring 연동 가이드:\n"
@@ -90,17 +127,24 @@ async def _transcribe_and_correct_from_bytes(
     audio_bytes: bytes,
     content_type: str,
     num_speakers: int | None,
+    live_messages: list[LiveTranscriptMessage] | None = None,
 ) -> list[TranscribeSegment]:
     # 1단계: Deepgram STT + 화자 분리
     segments = await deepgram.transcribe(audio_bytes, content_type, num_speakers)
 
     # 2단계: Gemini LLM으로 화자 오인식·짧은 발화 등 후처리
-    return await transcript_correction.correct_transcript(segments, num_speakers)
+    corrected_segments = await transcript_correction.correct_transcript(
+        segments, num_speakers
+    )
+
+    # 3단계: WebSocket 실시간 발화 로그 기준으로 최종 전사 보강
+    return merge_live_transcript(corrected_segments, live_messages or [])
 
 
 async def _transcribe_and_correct(
     audio: UploadFile,
     num_speakers: int | None,
+    live_messages: list[LiveTranscriptMessage] | None = None,
 ) -> list[TranscribeSegment]:
     # 업로드 파일을 읽어 STT + 후처리 파이프라인을 실행
     content_type = _resolve_content_type(audio)
@@ -109,6 +153,7 @@ async def _transcribe_and_correct(
         audio_bytes=audio_bytes,
         content_type=content_type,
         num_speakers=num_speakers,
+        live_messages=live_messages,
     )
 
 
@@ -119,6 +164,7 @@ async def _run_transcribe_application_run(
     num_speakers: int | None,
     meeting_id: str | None,
     project_id: str | None,
+    live_messages: list[LiveTranscriptMessage] | None = None,
 ) -> None:
     # 비동기 run의 전체 파이프라인을 단계별(phase)로 실행
     try:
@@ -127,6 +173,7 @@ async def _run_transcribe_application_run(
             audio_bytes=audio_bytes,
             content_type=content_type,
             num_speakers=num_speakers,
+            live_messages=live_messages,
         )
         partial_result = TranscribeAnalysisResponse(
             meeting_id=meeting_id,
@@ -178,7 +225,8 @@ async def _run_transcribe_application_run(
         "화자 분리 전사 세그먼트를 반환합니다.\n\n"
         "Spring 가이드: 이 엔드포인트는 전사 결과만 필요할 때 사용합니다. "
         "적용사항까지 필요하면 /api/transcribe/applications(동기) 또는 "
-        "/api/transcribe/applications/runs(비동기)를 사용하세요."
+        "/api/transcribe/applications/runs(비동기)를 사용하세요.\n\n"
+        f"{LIVE_MESSAGES_GUIDE}"
     ),
     responses={
         200: {
@@ -198,6 +246,7 @@ async def _run_transcribe_application_run(
                                 {
                                     "message_id": 1,
                                     "speaker": "Speaker 0",
+                                    "member_id": None,
                                     "start_time": "00:00:00",
                                     "end_time": "00:00:04",
                                     "text": "Swagger 에러 응답 예시가 부족합니다.",
@@ -302,9 +351,18 @@ async def transcribe_audio(
         le=20,
         description="화자 수 힌트(선택). 전달 시 화자 분리 정확도 개선에 도움.",
     ),
+    live_messages: str | None = Form(
+        default=None,
+        description=LIVE_MESSAGES_FIELD_DESCRIPTION,
+    ),
 ) -> ApiResponse[list[TranscribeSegment]]:
     # 전사+후처리 결과만 필요한 경우 사용하는 엔드포인트
-    segments = await _transcribe_and_correct(audio, num_speakers)
+    parsed_live_messages = parse_live_messages(live_messages)
+    segments = await _transcribe_and_correct(
+        audio,
+        num_speakers,
+        live_messages=parsed_live_messages,
+    )
     return ok_response(
         segments,
         code="TRANSCRIBE_200",
@@ -320,7 +378,9 @@ async def transcribe_audio(
         "오디오 업로드 후 STT, 후처리, 회의 분석/적용사항 추출을 한 번에 완료해 "
         "최종 결과를 동기 응답으로 반환합니다.\n\n"
         "Spring 가이드: 긴 회의에서는 타임아웃 위험이 크므로 "
-        "운영 환경에서는 /api/transcribe/applications/runs 비동기 방식을 권장합니다."
+        "운영 환경에서는 /api/transcribe/applications/runs "
+        "비동기 방식을 권장합니다.\n\n"
+        f"{LIVE_MESSAGES_GUIDE}"
     ),
     responses={
         413: {
@@ -371,9 +431,18 @@ async def transcribe_and_extract_applications(
         default=None,
         description="호출 측이 관리하는 프로젝트 ID(선택).",
     ),
+    live_messages: str | None = Form(
+        default=None,
+        description=LIVE_MESSAGES_FIELD_DESCRIPTION,
+    ),
 ) -> ApiResponse[TranscribeAnalysisResponse]:
     # 전사부터 회의 분석/적용사항 추출까지 동기로 한 번에 수행
-    transcript_segments = await _transcribe_and_correct(audio, num_speakers)
+    parsed_live_messages = parse_live_messages(live_messages)
+    transcript_segments = await _transcribe_and_correct(
+        audio,
+        num_speakers,
+        live_messages=parsed_live_messages,
+    )
     analysis_result = await extract_meeting_analysis(transcript_segments)
 
     return ok_response(
@@ -397,6 +466,7 @@ async def transcribe_and_extract_applications(
         "장시간 작업을 백그라운드로 실행합니다. "
         "즉시 run_id를 반환하며, 상태는 "
         "GET /api/transcribe/applications/runs/{run_id}로 조회합니다.\n\n"
+        f"{LIVE_MESSAGES_GUIDE}\n\n"
         f"{SPRING_ASYNC_GUIDE}"
     ),
     responses={
@@ -456,10 +526,15 @@ async def create_transcribe_application_run(
         default=None,
         description="호출 측이 관리하는 프로젝트 ID(선택).",
     ),
+    live_messages: str | None = Form(
+        default=None,
+        description=LIVE_MESSAGES_FIELD_DESCRIPTION,
+    ),
 ) -> ApiResponse[TranscribeAnalysisRunAccepted]:
     # 장시간 처리를 백그라운드 run으로 접수하고 run_id를 반환
     content_type = _resolve_content_type(audio)
     audio_bytes = await _read_audio_bytes(audio)
+    parsed_live_messages = parse_live_messages(live_messages)
     accepted = await create_run(meeting_id=meeting_id, project_id=project_id)
     background_tasks.add_task(
         _run_transcribe_application_run,
@@ -469,6 +544,7 @@ async def create_transcribe_application_run(
         num_speakers,
         meeting_id=meeting_id,
         project_id=project_id,
+        live_messages=parsed_live_messages,
     )
     return ok_response(
         accepted,
@@ -519,6 +595,7 @@ async def create_transcribe_application_run(
                                     {
                                         "message_id": 1,
                                         "speaker": "Speaker 0",
+                                        "member_id": None,
                                         "start_time": "00:00:00",
                                         "end_time": "00:00:04",
                                         "text": (

--- a/app/domains/transcribe/schemas.py
+++ b/app/domains/transcribe/schemas.py
@@ -1,10 +1,45 @@
-from pydantic import BaseModel, Field
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class LiveTranscriptMessage(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    type: str = Field(description='WebSocket 메시지 타입(예: "TEXT")')
+    meeting_id: int | str | None = Field(
+        default=None,
+        alias="meetingId",
+        description="회의 ID",
+    )
+    from_member_id: int | None = Field(
+        default=None,
+        alias="fromMemberId",
+        description="발화자 멤버 ID",
+    )
+    from_name: str | None = Field(
+        default=None,
+        alias="fromName",
+        description="발화자 이름",
+    )
+    timestamp: str = Field(description="회의 기준 발화 시작 시간 문자열")
+    target_member_id: int | None = Field(
+        default=None,
+        alias="targetMemberId",
+        description="대상 멤버 ID(선택)",
+    )
+    text: str = Field(description="WebSocket 실시간 발화 텍스트")
+    payload: dict[str, Any] | None = Field(default=None, description="부가 payload")
 
 
 # 전사 API의 응답 한 줄(발화 세그먼트) 타입 정의
 class TranscribeSegment(BaseModel):
     message_id: int = Field(description="발화 순서 번호")
     speaker: str = Field(description='화자 ID/이름 (예: "Speaker 0")')
+    member_id: int | None = Field(
+        default=None,
+        description="WebSocket 발화 로그와 매칭된 발화자 멤버 ID",
+    )
     start_time: str = Field(description="발화 시작 시각(HH:MM:SS)")
     end_time: str = Field(description="발화 종료 시각(HH:MM:SS)")
     text: str = Field(description="전사된 발화 텍스트")

--- a/app/domains/transcribe/services/live_transcript_merge.py
+++ b/app/domains/transcribe/services/live_transcript_merge.py
@@ -1,0 +1,312 @@
+import json
+import logging
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from string import punctuation
+
+from pydantic import TypeAdapter, ValidationError
+
+from app.core.errors import AppServiceError
+from app.domains.transcribe.schemas import LiveTranscriptMessage, TranscribeSegment
+
+logger = logging.getLogger(__name__)
+
+AMBIGUOUS_SHORT_TEXTS = {
+    "네",
+    "예",
+    "응",
+    "음",
+    "어",
+    "맞아요",
+    "맞습니다",
+    "아니요",
+    "확인",
+    "오케이",
+    "ok",
+    "okay",
+    "ㅋㅋ",
+    "ㅎㅎ",
+}
+MIN_MATCH_SCORE = 0.55
+MIN_CORRECTION_SCORE = 0.72
+MIN_SPEAKER_VOTES = 2
+MIN_SPEAKER_SHARE = 0.6
+MIN_SPEAKER_AVG_SCORE = 0.6
+TIME_WINDOW_SECONDS = 12.0
+_live_messages_adapter = TypeAdapter(list[LiveTranscriptMessage])
+
+
+@dataclass(frozen=True)
+class _LiveEntry:
+    index: int
+    message: LiveTranscriptMessage
+    seconds: float | None
+    normalized_text: str
+    is_ambiguous: bool
+
+
+@dataclass(frozen=True)
+class _SegmentMatch:
+    segment_index: int
+    live: _LiveEntry
+    score: float
+    text_similarity: float
+
+
+def parse_live_messages(raw: str | None) -> list[LiveTranscriptMessage]:
+    # multipart/form-data의 JSON 문자열을 WebSocket 발화 로그 DTO로 변환
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+        return _live_messages_adapter.validate_python(parsed)
+    except json.JSONDecodeError as e:
+        raise AppServiceError(
+            "live_messages는 JSON 배열 문자열이어야 합니다.",
+            status_code=422,
+        ) from e
+    except ValidationError as e:
+        raise AppServiceError(
+            f"live_messages 스키마 검증 실패: {e}",
+            status_code=422,
+        ) from e
+
+
+def merge_live_transcript(
+    segments: list[TranscribeSegment],
+    live_messages: list[LiveTranscriptMessage],
+) -> list[TranscribeSegment]:
+    # STT 결과와 WebSocket 발화 로그를 매칭해 최종 전사를 보강
+    live_entries = _prepare_live_entries(live_messages)
+    if not segments or not live_entries:
+        return segments
+
+    matches = _match_segments_to_live_messages(segments, live_entries)
+    speaker_mapping = _resolve_speaker_mapping(segments, matches)
+    return _apply_matches(segments, matches, speaker_mapping)
+
+
+def _prepare_live_entries(
+    live_messages: list[LiveTranscriptMessage],
+) -> list[_LiveEntry]:
+    entries: list[_LiveEntry] = []
+    for index, message in enumerate(live_messages):
+        if message.type.upper() != "TEXT":
+            continue
+        text = (message.text or "").strip()
+        if not text:
+            continue
+        if message.from_member_id is None or not message.from_name:
+            continue
+        normalized_text = _normalize_text(text)
+        if not normalized_text:
+            continue
+        entries.append(
+            _LiveEntry(
+                index=index,
+                message=message,
+                seconds=_parse_time_to_seconds(message.timestamp),
+                normalized_text=normalized_text,
+                is_ambiguous=_is_ambiguous_text(normalized_text),
+            )
+        )
+    return entries
+
+
+def _match_segments_to_live_messages(
+    segments: list[TranscribeSegment],
+    live_entries: list[_LiveEntry],
+) -> dict[int, _SegmentMatch]:
+    matches: dict[int, _SegmentMatch] = {}
+    used_live_indexes: set[int] = set()
+
+    for segment_index, segment in enumerate(segments):
+        segment_seconds = _parse_time_to_seconds(segment.start_time)
+        segment_text = _normalize_text(segment.text)
+        if not segment_text:
+            continue
+
+        best_match: _SegmentMatch | None = None
+        for live in live_entries:
+            if live.index in used_live_indexes:
+                continue
+            score, text_similarity = _score_match(
+                segment_index=segment_index,
+                segment_seconds=segment_seconds,
+                segment_text=segment_text,
+                live=live,
+            )
+            if score < MIN_MATCH_SCORE:
+                continue
+            if best_match is None or score > best_match.score:
+                best_match = _SegmentMatch(
+                    segment_index=segment_index,
+                    live=live,
+                    score=score,
+                    text_similarity=text_similarity,
+                )
+
+        if best_match is not None:
+            matches[segment_index] = best_match
+            used_live_indexes.add(best_match.live.index)
+
+    return matches
+
+
+def _score_match(
+    segment_index: int,
+    segment_seconds: float | None,
+    segment_text: str,
+    live: _LiveEntry,
+) -> tuple[float, float]:
+    text_similarity = SequenceMatcher(None, segment_text, live.normalized_text).ratio()
+    time_score = _time_score(segment_seconds, live.seconds)
+    order_score = _order_score(segment_index, live.index)
+
+    score = (time_score * 0.45) + (text_similarity * 0.45) + (order_score * 0.10)
+    if live.is_ambiguous:
+        score *= 0.45
+    return score, text_similarity
+
+
+def _resolve_speaker_mapping(
+    segments: list[TranscribeSegment],
+    matches: dict[int, _SegmentMatch],
+) -> dict[str, tuple[int, str, float]]:
+    votes: dict[str, dict[tuple[int, str], list[float]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    for segment_index, match in matches.items():
+        if match.live.is_ambiguous:
+            continue
+        segment = segments[segment_index]
+        member_key = (
+            match.live.message.from_member_id,
+            match.live.message.from_name or "",
+        )
+        if member_key[0] is None or not member_key[1]:
+            continue
+        votes[segment.speaker][member_key].append(match.score)
+
+    resolved: dict[str, tuple[int, str, float]] = {}
+    for speaker, member_scores in votes.items():
+        flattened_scores = [
+            score for scores in member_scores.values() for score in scores
+        ]
+        if len(flattened_scores) < MIN_SPEAKER_VOTES:
+            continue
+
+        best_member, best_scores = max(
+            member_scores.items(),
+            key=lambda item: sum(item[1]),
+        )
+        best_count = len(best_scores)
+        share = best_count / len(flattened_scores)
+        avg_score = sum(best_scores) / best_count
+        if share < MIN_SPEAKER_SHARE or avg_score < MIN_SPEAKER_AVG_SCORE:
+            continue
+
+        member_id, member_name = best_member
+        if member_id is None:
+            continue
+        resolved[speaker] = (member_id, member_name, avg_score)
+        logger.info(
+            "speaker mapped: %s -> %s(member_id=%s, confidence=%.2f)",
+            speaker,
+            member_name,
+            member_id,
+            avg_score,
+        )
+
+    return resolved
+
+
+def _apply_matches(
+    segments: list[TranscribeSegment],
+    matches: dict[int, _SegmentMatch],
+    speaker_mapping: dict[str, tuple[int, str, float]],
+) -> list[TranscribeSegment]:
+    corrected: list[TranscribeSegment] = []
+    for segment_index, segment in enumerate(segments):
+        update: dict[str, object] = {}
+
+        speaker_match = speaker_mapping.get(segment.speaker)
+        if speaker_match:
+            member_id, member_name, _ = speaker_match
+            update["speaker"] = member_name
+            update["member_id"] = member_id
+
+        match = matches.get(segment_index)
+        if match and match.score >= MIN_CORRECTION_SCORE:
+            live_text = (match.live.message.text or "").strip()
+            if live_text:
+                update["text"] = live_text
+                if live_text != segment.text:
+                    logger.info(
+                        "transcript corrected: message_id=%s score=%.2f",
+                        segment.message_id,
+                        match.score,
+                    )
+
+        corrected.append(segment.model_copy(update=update))
+
+    return corrected
+
+
+def _parse_time_to_seconds(value: str | None) -> float | None:
+    if not value:
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+
+    # ISO 절대시각은 STT 상대 시간과 기준이 달라서 시간 점수에는 사용하지 않는다.
+    if "T" in raw or re.match(r"^\d{4}-\d{2}-\d{2}", raw):
+        return None
+
+    parts = raw.split(":")
+    try:
+        if len(parts) == 3:
+            hours = float(parts[0])
+            minutes = float(parts[1])
+            seconds = float(parts[2])
+            return hours * 3600 + minutes * 60 + seconds
+        if len(parts) == 2:
+            minutes = float(parts[0])
+            seconds = float(parts[1])
+            return minutes * 60 + seconds
+        if len(parts) == 1:
+            return float(parts[0])
+    except ValueError:
+        return None
+    return None
+
+
+def _time_score(segment_seconds: float | None, live_seconds: float | None) -> float:
+    if segment_seconds is None or live_seconds is None:
+        return 0.4
+    diff = abs(segment_seconds - live_seconds)
+    if diff >= TIME_WINDOW_SECONDS:
+        return 0.0
+    return max(0.0, 1.0 - (diff / TIME_WINDOW_SECONDS))
+
+
+def _order_score(segment_index: int, live_index: int) -> float:
+    diff = abs(segment_index - live_index)
+    if diff >= 6:
+        return 0.0
+    return max(0.0, 1.0 - (diff / 6))
+
+
+def _normalize_text(value: str) -> str:
+    cleaned = re.sub(rf"[{re.escape(punctuation)}]", " ", value.lower())
+    cleaned = re.sub(r"[^\w가-힣\s]", " ", cleaned)
+    return " ".join(cleaned.split())
+
+
+def _is_ambiguous_text(value: str) -> bool:
+    if value in AMBIGUOUS_SHORT_TEXTS:
+        return True
+    return len(value.replace(" ", "")) <= 2

--- a/tests/test_live_transcript_merge.py
+++ b/tests/test_live_transcript_merge.py
@@ -1,0 +1,185 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.errors import AppServiceError
+from app.domains.transcribe.schemas import LiveTranscriptMessage, TranscribeSegment
+from app.domains.transcribe.services.live_transcript_merge import (
+    merge_live_transcript,
+    parse_live_messages,
+)
+from app.main import app
+
+
+def _segment(
+    message_id: int,
+    speaker: str,
+    start_time: str,
+    text: str,
+) -> TranscribeSegment:
+    return TranscribeSegment(
+        message_id=message_id,
+        speaker=speaker,
+        start_time=start_time,
+        end_time=start_time,
+        text=text,
+        is_final=True,
+    )
+
+
+def test_parse_live_messages_accepts_spring_camel_case_payload():
+    raw = """
+    [
+      {
+        "type": "TEXT",
+        "meetingId": 123,
+        "fromMemberId": 1,
+        "fromName": "김준용",
+        "timestamp": "00:01:48",
+        "targetMemberId": 2,
+        "text": "안녕하세요",
+        "payload": {"key": "value"}
+      }
+    ]
+    """
+
+    messages = parse_live_messages(raw)
+
+    assert messages[0].meeting_id == 123
+    assert messages[0].from_member_id == 1
+    assert messages[0].from_name == "김준용"
+    assert messages[0].target_member_id == 2
+
+
+def test_parse_live_messages_invalid_json_raises_422():
+    with pytest.raises(AppServiceError) as exc_info:
+        parse_live_messages("not-json")
+
+    assert exc_info.value.status_code == 422
+
+
+def test_merge_live_transcript_replaces_speaker_and_text_from_live_messages():
+    segments = [
+        _segment(
+            1,
+            "Speaker 0",
+            "00:01:48",
+            "보고를 할 때는 지난번에 우리가 어떤 이슈가 있었고 그거를 해결했는데",
+        ),
+        _segment(
+            2,
+            "Speaker 0",
+            "00:02:10",
+            "네 번은 문제가 있던 거를 표로 보여줘야 됩니다",
+        ),
+    ]
+    live_messages = [
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=123,
+            fromMemberId=1,
+            fromName="김준용",
+            timestamp="00:01:48",
+            text=(
+                "보고를 할 때는 지난번에 우리가 어떤 이슈가 있었고 "
+                "그걸 어떻게 해결했는지 보여줘야 해"
+            ),
+        ),
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=123,
+            fromMemberId=1,
+            fromName="김준용",
+            timestamp="00:02:10",
+            text="네 번은 문제가 있던 거를 표로 보여줘야 됩니다",
+        ),
+    ]
+
+    merged = merge_live_transcript(segments, live_messages)
+
+    assert merged[0].speaker == "김준용"
+    assert merged[0].member_id == 1
+    assert merged[0].text == (
+        "보고를 할 때는 지난번에 우리가 어떤 이슈가 있었고 "
+        "그걸 어떻게 해결했는지 보여줘야 해"
+    )
+    assert merged[1].speaker == "김준용"
+    assert merged[1].member_id == 1
+
+
+def test_merge_live_transcript_keeps_stt_when_only_ambiguous_short_messages_exist():
+    segments = [
+        _segment(1, "Speaker 0", "00:00:01", "네"),
+        _segment(2, "Speaker 0", "00:00:03", "네"),
+    ]
+    live_messages = [
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=123,
+            fromMemberId=1,
+            fromName="김준용",
+            timestamp="00:00:01",
+            text="네",
+        ),
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=123,
+            fromMemberId=1,
+            fromName="김준용",
+            timestamp="00:00:03",
+            text="네",
+        ),
+    ]
+
+    merged = merge_live_transcript(segments, live_messages)
+
+    assert merged[0].speaker == "Speaker 0"
+    assert merged[0].member_id is None
+    assert merged[1].speaker == "Speaker 0"
+    assert merged[1].member_id is None
+
+
+def test_merge_live_transcript_uses_text_and_order_when_timestamp_is_iso_string():
+    segments = [
+        _segment(1, "Speaker 0", "00:00:01", "안녀 하세요"),
+        _segment(2, "Speaker 0", "00:00:03", "회의 시작하겠습니다"),
+    ]
+    live_messages = [
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=123,
+            fromMemberId=1,
+            fromName="김준용",
+            timestamp="2026-05-04T17:00:00",
+            text="안녕하세요",
+        ),
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=123,
+            fromMemberId=1,
+            fromName="김준용",
+            timestamp="2026-05-04T17:00:02",
+            text="회의 시작하겠습니다",
+        ),
+    ]
+
+    merged = merge_live_transcript(segments, live_messages)
+
+    assert merged[0].speaker == "김준용"
+    assert merged[0].member_id == 1
+    assert merged[1].speaker == "김준용"
+
+
+class TestLiveMessagesEndpoint:
+    client = TestClient(app)
+
+    def test_transcribe_applications_rejects_invalid_live_messages_json(self):
+        response = self.client.post(
+            "/api/transcribe/applications",
+            files={"audio": ("sample.wav", b"fake-audio", "audio/wav")},
+            data={"live_messages": "not-json"},
+        )
+
+        assert response.status_code == 422
+        body = response.json()
+        assert body["isSuccess"] is False
+        assert body["code"] == "COMMON_422"


### PR DESCRIPTION
<!-- PR 제목 예시 -> [feat/#3] Deepgram 음성 전사 API 구현 -->

## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->
회의 종료 후 녹음 기반 STT 결과와 Spring WebSocket 실시간 발화 로그를 병합해 최종 전사 품질을 개선했습니다.

기존 `Speaker 0`, `Speaker 1` 형태의 화자를 WebSocket 발화 로그의 실제 사용자 이름으로 보강하고, 매칭 신뢰도가 충분한 경우 전사 텍스트도 WebSocket 발화 기준으로 보정합니다.

보강된 전사 결과는 회의 분석/적용사항 추출에 사용됩니다.
## 📄 작업 내용
- WebSocket 실시간 발화 로그 DTO 추가
  - `LiveTranscriptMessage`
  - Spring camelCase 필드 alias 지원
  - `meetingId`, `fromMemberId`, `fromName`, `targetMemberId`
- 전사 응답 필드 보강
  - `TranscribeSegment.member_id` optional 추가
  - 기존 `speaker` 필드는 유지하되, 매칭 성공 시 실제 이름으로 치환
- STT 결과와 실시간 발화 로그 병합 서비스 추가
  - 시간 근접도
  - 발화 순서
  - 텍스트 유사도 기반 매칭
- 매칭 성공 시 최종 전사 보강
  - `speaker`: `Speaker N` → 실제 사용자 이름
  - `member_id`: WebSocket `fromMemberId`
  - `text`: 신뢰도 충분 시 WebSocket 발화 텍스트로 보정
- 전사 API에 `live_messages` form field 추가
  - `POST /api/transcribe`
  - `POST /api/transcribe/applications`
  - `POST /api/transcribe/applications/runs`
- 보강된 transcript를 회의 분석/적용사항 추출 입력으로 사용
- Swagger request body 설명에 `live_messages` 예시 추가
- 관련 테스트 추가
## 📌 관련 이슈
- close #29

## 🔌 API 변경사항 (해당 시)
<!-- 새로운 엔드포인트 추가 또는 기존 변경이 있다면 적어주세요. -->
<img width="1410" height="853" alt="image" src="https://github.com/user-attachments/assets/e0d870bc-649e-496f-a9f3-38768f76dfd2" />

## 💬 기타 사항
<!-- 리뷰어가 알면 좋을 내용이 있다면 적어주세요 -->
- payload, targetMemberId는 현재 AI 서버 로직에서는 사용하지 않지만 Spring WebSocket DTO 호환을 위해 optional로 수신합니다.
- timestamp는 가능하면 회의 시작 기준 상대 시간(HH:MM:SS)으로 전달하는 것을 권장합니다.
- 절대시각 형태로 전달되는 경우 시간 기준 매칭은 사용하지 않고 순서/텍스트 유사도 중심으로 매칭합니다.
- 실제 E2E 검증은 Spring에서 회의 종료 후 FastAPI 분석 요청에 live_messages를 주입한 뒤 확인이 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 실시간 라이브 트랜스크립트 병합 기능을 추가했습니다. 이제 WebSocket 메시지를 전사 결과와 자동으로 병합할 수 있습니다.
  * 발화자 식별 기능을 개선하여 회의 참여자와의 매칭 정확도를 향상시켰습니다.

* **Tests**
  * 라이브 트랜스크립트 병합 및 파싱 관련 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->