### PR TITLE
[fix/#30] 커밋 분석 식별자를 commit_hash 기준으로 변경

### DIFF
--- a/app/domains/commit/router.py
+++ b/app/domains/commit/router.py
@@ -50,14 +50,15 @@ COMMIT_ANALYZE_ASYNC_GUIDE = (
     description="Spring에서 커밋 메시지와 diff를 받아 "
     "LLM(Gemini)으로 요약한 결과를 반환합니다.\n\n"
     "**Spring 연동 입력:**\n"
-    "- Spring commit detail의 `hash`는 `commit_hash`로 변환해 전달합니다.\n"
+    "- `commit_hash`는 외부 식별자로 필수입니다 (ChromaDB 저장 키).\n"
+    "- `commit_id`는 Spring DB PK로 선택입니다. 보내면 매칭 응답 join 편의를 위해 "
+    "메타에 함께 저장됩니다.\n"
     "- Spring repository 식별자는 `repository_id`로 전달합니다.\n\n"
     "**백그라운드 임베딩 저장:**\n"
     "- 구조화 임베딩 텍스트 생성 → Gemini Embedding API 벡터 변환 → "
     "ChromaDB(commit_embeddings) 저장\n"
-    "- 동일 commit_id 재호출 시 기존 데이터를 덮어씁니다 (upsert)\n"
-    "- commit_hash가 포함되면 매칭 결과 식별용 메타데이터로 함께 저장합니다\n"
-    "- 문서 ID: commit_{commit_id}\n"
+    "- 동일 commit_hash 재호출 시 기존 데이터를 덮어씁니다 (upsert)\n"
+    "- 문서 ID: commit_{commit_hash}\n"
     "- 임베딩 텍스트: title: repository-{repository_id} {subject} | text: "
     "변경요약: | 기술키워드: | 변경방향: | 파일맥락: ",
     responses={
@@ -70,6 +71,7 @@ COMMIT_ANALYZE_ASYNC_GUIDE = (
                         "code": "COMMON_200",
                         "message": "요청이 성공적으로 처리되었습니다.",
                         "result": {
+                            "commit_hash": ("cb2222fb915f9dfbd5b22eded57dadd57f225798"),
                             "commit_id": 4,
                             "summary": (
                                 "Swagger 에러 문서화를 위한 "
@@ -113,14 +115,18 @@ async def analyze_commit(
     summary = await summarize_commit(request.message, filtered_files)
     background_tasks.add_task(
         generate_embedding_text,
-        request.commit_id,
-        request.commit_hash,
-        request.repository_id,
-        request.message,
-        filtered_files,
+        commit_hash=request.commit_hash,
+        repository_id=request.repository_id,
+        message=request.message,
+        changed_file_list=filtered_files,
+        commit_id=request.commit_id,
     )
     return ok_response(
-        CommitAnalyzeResponse(commit_id=request.commit_id, summary=summary)
+        CommitAnalyzeResponse(
+            commit_hash=request.commit_hash,
+            commit_id=request.commit_id,
+            summary=summary,
+        )
     )
 
 
@@ -151,8 +157,8 @@ async def analyze_commit(
                             "run_id": "550e8400e29b41d4a716446655440000",
                             "status": "queued",
                             "phase": "queued",
-                            "commit_id": 4,
                             "commit_hash": ("cb2222fb915f9dfbd5b22eded57dadd57f225798"),
+                            "commit_id": 4,
                             "repository_id": 1,
                         },
                     }
@@ -206,18 +212,18 @@ async def create_commit_analyze_run(
                             "run_id": "550e8400e29b41d4a716446655440000",
                             "status": "completed",
                             "phase": "embedding_ready",
-                            "commit_id": 4,
                             "commit_hash": ("cb2222fb915f9dfbd5b22eded57dadd57f225798"),
+                            "commit_id": 4,
                             "repository_id": 1,
                             "submitted_at": "2026-04-27T09:00:00Z",
                             "started_at": "2026-04-27T09:00:01Z",
                             "finished_at": "2026-04-27T09:00:10Z",
                             "error": None,
                             "result": {
-                                "commit_id": 4,
                                 "commit_hash": (
                                     "cb2222fb915f9dfbd5b22eded57dadd57f225798"
                                 ),
+                                "commit_id": 4,
                                 "repository_id": 1,
                                 "summary": (
                                     "Swagger 에러 문서화를 위한 "

--- a/app/domains/commit/schemas.py
+++ b/app/domains/commit/schemas.py
@@ -19,11 +19,20 @@ class ChangedFile(BaseModel):
 
 
 class CommitAnalyzeRequest(BaseModel):
-    commit_id: int = Field(ge=0, description="커밋 ID")
-    commit_hash: str | None = Field(
-        default=None,
+    commit_hash: str = Field(
         pattern=r"^[a-fA-F0-9]{7,64}$",
-        description="Git 커밋 해시(Spring commit detail의 hash를 commit_hash로 전달)",
+        description=(
+            "Git 커밋 해시(외부 식별자, ChromaDB 저장 키). "
+            "Spring commit detail의 hash를 그대로 전달합니다."
+        ),
+    )
+    commit_id: int | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Spring DB PK (선택). 보내면 매칭 응답 "
+            "join 편의용으로 메타에 함께 저장됩니다."
+        ),
     )
     repository_id: int = Field(ge=0, description="Spring 레포지토리 ID")
     message: str = Field(min_length=1, description="커밋 메시지")
@@ -33,13 +42,17 @@ class CommitAnalyzeRequest(BaseModel):
 
 
 class CommitAnalyzeResponse(BaseModel):
-    commit_id: int = Field(description="커밋 ID")
+    commit_hash: str = Field(description="커밋 해시")
+    commit_id: int | None = Field(
+        default=None,
+        description="Spring DB PK (요청에 포함된 경우 echo)",
+    )
     summary: str = Field(description="커밋 요약")
 
 
 class CommitAnalyzeRunResult(BaseModel):
-    commit_id: int = Field(description="커밋 ID")
-    commit_hash: str | None = Field(default=None, description="커밋 해시")
+    commit_hash: str = Field(description="커밋 해시")
+    commit_id: int | None = Field(default=None, description="Spring DB PK")
     repository_id: int = Field(description="Spring 레포지토리 ID")
     summary: str = Field(description="커밋 요약")
     embedding_ready: bool = Field(description="커밋 임베딩 저장 완료 여부")
@@ -53,8 +66,8 @@ class CommitAnalyzeRunAccepted(BaseModel):
     phase: CommitAnalyzeRunPhase = Field(
         description='실행 단계("queued" 고정으로 시작)'
     )
-    commit_id: int = Field(description="커밋 ID")
-    commit_hash: str | None = Field(default=None, description="커밋 해시")
+    commit_hash: str = Field(description="커밋 해시")
+    commit_id: int | None = Field(default=None, description="Spring DB PK")
     repository_id: int = Field(description="Spring 레포지토리 ID")
 
 
@@ -69,8 +82,8 @@ class CommitAnalyzeRunStatus(BaseModel):
             "embedding_ready(completed) 이후 /api/commit/match 호출을 권장합니다."
         )
     )
-    commit_id: int = Field(description="커밋 ID")
-    commit_hash: str | None = Field(default=None, description="커밋 해시")
+    commit_hash: str = Field(description="커밋 해시")
+    commit_id: int | None = Field(default=None, description="Spring DB PK")
     repository_id: int = Field(description="Spring 레포지토리 ID")
     submitted_at: str = Field(description="실행 접수 시각(UTC ISO8601)")
     started_at: str | None = Field(

--- a/app/domains/commit/services/analyze_runs.py
+++ b/app/domains/commit/services/analyze_runs.py
@@ -224,11 +224,11 @@ async def run_commit_analyze_pipeline(run_id: str) -> None:
             result=result,
         )
         await store_commit_embedding(
-            commit_id=request.commit_id,
             commit_hash=request.commit_hash,
             repository_id=request.repository_id,
             message=request.message,
             changed_file_list=filtered_files,
+            commit_id=request.commit_id,
         )
 
         completed_result = result.model_copy(update={"embedding_ready": True})

--- a/app/domains/commit/services/summarize.py
+++ b/app/domains/commit/services/summarize.py
@@ -217,11 +217,11 @@ async def summarize_commit(
 
 
 async def store_commit_embedding(
-    commit_id: int,
-    commit_hash: str | None,
+    commit_hash: str,
     repository_id: int,
     message: str,
     changed_file_list: list[ChangedFile],
+    commit_id: int | None = None,
 ) -> None:
     """커밋 임베딩용 구조화 텍스트를 생성하고 ChromaDB에 저장한다."""
     client = _get_client()
@@ -246,19 +246,19 @@ async def store_commit_embedding(
     # 3) 임베딩 벡터 생성
     embedding = await _generate_embedding(embedding_text)
 
-    # 4) ChromaDB 저장
+    # 4) ChromaDB 저장 (doc_id는 hash 기반, commit_id는 보조 메타로 저장)
     collection = get_commit_collection()
-    doc_id = f"commit_{commit_id}"
-    metadata = {
-        "commit_id": commit_id,
+    doc_id = f"commit_{commit_hash}"
+    metadata: dict[str, str | int] = {
+        "commit_hash": commit_hash,
         "commit_message": commit_subject,
         "repository_id": repository_id,
         "direction": ",".join(parsed.directions),
         "tech_keywords_csv": ",".join(parsed.tech_keywords),
         "module_tags_csv": ",".join(parsed.module_tags),
     }
-    if commit_hash:
-        metadata["commit_hash"] = commit_hash
+    if commit_id is not None:
+        metadata["commit_id"] = commit_id
     await asyncio.to_thread(
         collection.upsert,
         ids=[doc_id],
@@ -266,24 +266,31 @@ async def store_commit_embedding(
         embeddings=[embedding],
         metadatas=[metadata],
     )
-    logger.info("커밋 %d 임베딩 저장 완료: %s", commit_id, doc_id)
+    logger.info(
+        "커밋 임베딩 저장 완료: doc_id=%s commit_id=%s",
+        doc_id,
+        commit_id,
+    )
 
 
 async def generate_embedding_text(
-    commit_id: int,
-    commit_hash: str | None,
+    commit_hash: str,
     repository_id: int,
     message: str,
     changed_file_list: list[ChangedFile],
+    commit_id: int | None = None,
 ) -> None:
     """백그라운드에서 임베딩용 구조화 텍스트 생성. 응답을 블로킹하지 않음."""
     try:
         await store_commit_embedding(
-            commit_id=commit_id,
             commit_hash=commit_hash,
             repository_id=repository_id,
             message=message,
             changed_file_list=changed_file_list,
+            commit_id=commit_id,
         )
     except Exception:
-        logger.exception("커밋 %d 임베딩 텍스트 생성 실패", commit_id)
+        logger.exception(
+            "커밋 임베딩 텍스트 생성 실패: commit_hash=%s",
+            commit_hash,
+        )


### PR DESCRIPTION
<!-- PR 제목 예시 -> [feat/#3] Deepgram 음성 전사 API 구현 -->

## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->
Spring 측에서 커밋 동기화 직후(트랜잭션 커밋 전 등) 분석 요청을 보낼 수 있도록  
커밋 분석 요청의 외부 식별자를 Spring DB PK(`commit_id`)에서 git 해시(`commit_hash`)로 전환했습니다.

## 📄 작업 내용
- `CommitAnalyzeRequest`의 `commit_hash`를 필수, `commit_id`를 옵셔널(`int | None`)로 변경
- `CommitAnalyzeResponse` / `CommitAnalyzeRunResult` / `CommitAnalyzeRunAccepted` / `CommitAnalyzeRunStatus` 모델에 동일 정책 적용
- ChromaDB `commit_embeddings` 문서 ID를 `commit_{commit_hash}` 형식으로 통일
- 메타데이터에 `commit_hash`는 항상 저장, `commit_id`는 전달된 경우에만 보조 키로 저장
- `store_commit_embedding` / `generate_embedding_text` 시그니처를 hash 필수로 재정렬
- `analyze_commit` 라우터의 `BackgroundTasks` 호출과 `analyze_runs` 파이프라인을 새 시그니처에 맞춰 갱신
- Swagger description / 예시 페이로드를 `commit_hash` 우선으로 갱신

## 📌 관련 이슈
- close #30 

## 🔌 API 변경사항 (해당 시)
<!-- 새로운 엔드포인트 추가 또는 기존 변경이 있다면 적어주세요. -->

### 요청 스키마 (`POST /api/commit/analyze`, `POST /api/commit/analyze/runs`)
| 필드 | Before | After |
|------|--------|-------|
| `commit_hash` | 옵셔널 | **필수** (`^[a-fA-F0-9]{7,64}$`) |
| `commit_id` | 필수 | **옵셔널** (`null` 허용) |
| `repository_id` | 필수 | 필수 (변경 없음) |

### 응답 스키마
- 모든 응답에 `commit_hash` 필수 포함
- `commit_id`는 요청 시 전달된 경우에만 echo로 채워짐

### ChromaDB 저장 형식
- 문서 ID: `commit_{commit_id}` → `commit_{commit_hash}`
- 메타데이터: `commit_hash` 항상, `commit_id` 옵셔널
## 💬 기타 사항
<!-- 리뷰어가 알면 좋을 내용이 있다면 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 커밋 분석 API의 식별자 체계를 개선했습니다. 커밋 해시를 필수 식별자로 사용하도록 변경되었으며, 커밋 ID는 선택 사항이 되었습니다.
  * API 요청 및 응답에서 커밋 해시 정보가 일관되게 포함되도록 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->