### PR TITLE
[refactor/#34] 적용사항 타임라인 화자 필드를 memberId 기준으로 변경

### DIFF
--- a/app/domains/meeting_analysis/router.py
+++ b/app/domains/meeting_analysis/router.py
@@ -25,7 +25,7 @@ router = APIRouter(prefix="/meeting-analysis", tags=["meeting-analysis"])
         "오디오 재업로드 없이 프롬프트 변경 실험, "
         "실패 재시도, 운영 재처리에 사용합니다.\n\n"
         "팀 공유 FAQ:\n"
-        "- timeline.speaker_id가 null일 수 있습니다(오탐 방지 목적).\n"
+        "- timeline.member_id가 null일 수 있습니다(오탐 방지 목적).\n"
         "- summary_ready 단계 값과 completed 단계 값은 일부 필드가 다를 수 있습니다.\n"
         "- 이 API가 생성하는 applications[].application_id는 보통 null입니다. "
         "Spring이 적용사항을 DB에 저장한 뒤 발급한 applicationId를 "
@@ -95,7 +95,7 @@ router = APIRouter(prefix="/meeting-analysis", tags=["meeting-analysis"])
                                             {
                                                 "timestamp": "00:03:12",
                                                 "step": "이슈제기",
-                                                "speaker_id": "Speaker 0",
+                                                "member_id": 1,
                                                 "content": (
                                                     "Swagger에서 에러 응답 예시가 "
                                                     "부족하다는 문제가 제기됨"
@@ -108,7 +108,7 @@ router = APIRouter(prefix="/meeting-analysis", tags=["meeting-analysis"])
                                             {
                                                 "timestamp": "00:06:20",
                                                 "step": "대안논의",
-                                                "speaker_id": "Speaker 1",
+                                                "member_id": 2,
                                                 "content": (
                                                     "어노테이션 기반 예시 "
                                                     "문서화가 논의됨"
@@ -121,7 +121,7 @@ router = APIRouter(prefix="/meeting-analysis", tags=["meeting-analysis"])
                                             {
                                                 "timestamp": "00:09:40",
                                                 "step": "적용합의",
-                                                "speaker_id": "Speaker 0",
+                                                "member_id": 1,
                                                 "content": (
                                                     "ApiErrorCodeExample 어노테이션을 "
                                                     "추가하기로 합의함"
@@ -255,7 +255,7 @@ async def create_application_embeddings(
                                         {
                                             "timestamp": "00:09:40",
                                             "step": "적용합의",
-                                            "speaker_id": "Speaker 0",
+                                            "member_id": 1,
                                             "content": (
                                                 "ApiErrorCodeExample 어노테이션을 "
                                                 "추가하기로 합의함"

--- a/app/domains/meeting_analysis/schemas.py
+++ b/app/domains/meeting_analysis/schemas.py
@@ -32,13 +32,12 @@ class MeetingAnalysis(BaseModel):
 class ApplicationTimelineItem(BaseModel):
     timestamp: str = Field(description="해당 단계 시각(HH:MM:SS)")
     step: str = Field(description="이슈제기/대안논의/적용합의")
-    speaker_id: str | None = Field(
+    member_id: int | None = Field(
         default=None,
         description=(
-            '타임라인 발화 화자 ID(예: "Speaker 0"). '
-            "짧은 응답어(예: 네/확인)처럼 화자 추정 신뢰도가 낮은 경우 "
-            "억지 매핑을 피하기 위해 null로 반환될 수 있습니다. "
-            'UI에서는 "미확인 화자" 등으로 표시를 권장합니다.'
+            "WebSocket 발화 로그와 매칭된 Spring 멤버 ID. "
+            "실시간 발화 로그가 없거나 매칭 신뢰도가 낮은 경우 "
+            "null로 반환될 수 있습니다."
         ),
     )
     content: str = Field(description="타임라인 요약 한 문장")

--- a/app/domains/meeting_analysis/services/extraction.py
+++ b/app/domains/meeting_analysis/services/extraction.py
@@ -108,7 +108,8 @@ APPLICATION_POLICY_PROMPT = "\n".join(
         "[정책 3: 적용사항 타임라인 정책]",
         "1. 이슈 제기 -> 대안 논의 -> 적용 합의 시점 순으로 구성한다.",
         "2. 적용사항과 직접 관련된 흐름만 표시하고 단순 발언은 제외한다.",
-        "3. 반드시 실제 발화(Utterance) 원문과 화자 ID를 포함한다.",
+        "3. 반드시 실제 발화(Utterance) 원문과 member_id를 포함한다.",
+        "   member_id는 STT 데이터의 member_id 값을 사용하고, 없으면 null로 둔다.",
         "4. timeline의 content는 간략한 한 문장으로 작성한다.",
         "------------------------------------------------------------",
         "",
@@ -131,7 +132,7 @@ APPLICATION_POLICY_PROMPT = "\n".join(
         "        {",
         '          "timestamp": "...",',
         '          "step": "이슈제기/대안논의/적용합의",',
-        '          "speaker_id": "Speaker 0",',
+        '          "member_id": 1,',
         '          "content": "간략 요약 한 문장",',
         '          "utterance": "실제 발화 원문"',
         "        }",
@@ -193,8 +194,9 @@ APPLICATIONS_ONLY_PROMPT = "\n".join(
         "",
         "[정책 3: 타임라인]",
         "1. 이슈제기 -> 대안논의 -> 적용합의 순서를 따른다.",
-        "2. 실제 발화 원문과 화자 ID를 포함한다.",
-        "3. content는 간략한 한 문장으로 작성한다.",
+        "2. 실제 발화 원문과 member_id를 포함한다.",
+        "3. member_id는 STT 데이터의 member_id 값을 사용하고, 없으면 null로 둔다.",
+        "4. content는 간략한 한 문장으로 작성한다.",
         "",
         "[출력 JSON 구조]",
         "{",
@@ -206,7 +208,7 @@ APPLICATIONS_ONLY_PROMPT = "\n".join(
         "        {",
         '          "timestamp": "...",',
         '          "step": "이슈제기/대안논의/적용합의",',
-        '          "speaker_id": "Speaker 0",',
+        '          "member_id": 1,',
         '          "content": "간략 요약 한 문장",',
         '          "utterance": "실제 발화 원문"',
         "        }",
@@ -460,19 +462,18 @@ def _match_score(utterance: str, segment_text: str) -> int:
     return 0
 
 
-def _infer_speaker_id(
+def _infer_timeline_member_id(
     utterance: str,
     timestamp: str,
     segments: list[TranscribeSegment],
-    valid_speakers: set[str],
-) -> str | None:
-    # timestamp + utterance 유사도로 timeline 화자를 추정
+) -> int | None:
+    # timestamp + utterance 유사도로 timeline 발화의 member_id를 추정
     normalized_utterance = _normalize_text(utterance)
     target_seconds = _parse_timestamp_to_seconds(timestamp)
     timestamp_candidates: list[TranscribeSegment] = []
     if target_seconds is not None:
         for segment in segments:
-            if segment.speaker not in valid_speakers:
+            if segment.member_id is None:
                 continue
             start_seconds = _parse_timestamp_to_seconds(segment.start_time)
             end_seconds = _parse_timestamp_to_seconds(segment.end_time)
@@ -482,7 +483,7 @@ def _infer_speaker_id(
                 timestamp_candidates.append(segment)
 
         if len(timestamp_candidates) == 1:
-            return timestamp_candidates[0].speaker
+            return timestamp_candidates[0].member_id
 
         if len(timestamp_candidates) > 1 and not _is_ambiguous_utterance(
             normalized_utterance
@@ -502,7 +503,7 @@ def _infer_speaker_id(
                 reverse=True,
             )
             if scored and scored[0][0] > 0:
-                return scored[0][1].speaker
+                return scored[0][1].member_id
 
     if _is_ambiguous_utterance(normalized_utterance):
         return None
@@ -517,55 +518,55 @@ def _infer_speaker_id(
                 segment,
             )
             for segment in segments
-            if segment.speaker in valid_speakers
+            if segment.member_id is not None
         ),
         key=lambda item: item[0],
         reverse=True,
     )
     if global_scored and global_scored[0][0] >= 3:
-        return global_scored[0][1].speaker
+        return global_scored[0][1].member_id
     return None
 
 
-def _normalize_timeline_speaker_ids(
+def _normalize_timeline_member_ids(
     result: MeetingAnalysisResult,
     segments: list[TranscribeSegment],
 ) -> None:
-    # LLM이 생성한 잘못된 speaker_id를 가능한 범위에서 보정
-    valid_speakers = [segment.speaker for segment in segments if segment.speaker]
-    valid_speaker_set = set(valid_speakers)
+    # LLM이 생성한 member_id를 전사 세그먼트 기준으로 검증/보정
+    valid_member_ids = {
+        segment.member_id for segment in segments if segment.member_id is not None
+    }
     corrected_count = 0
     unresolved_count = 0
 
     for application in result.applications:
         for item in application.timeline:
-            if item.speaker_id in valid_speaker_set:
+            if item.member_id in valid_member_ids:
                 continue
 
             inferred = None
-            if valid_speaker_set:
-                inferred = _infer_speaker_id(
+            if valid_member_ids:
+                inferred = _infer_timeline_member_id(
                     utterance=item.utterance,
                     timestamp=item.timestamp,
                     segments=segments,
-                    valid_speakers=valid_speaker_set,
                 )
-            if inferred:
-                item.speaker_id = inferred
+            if inferred is not None:
+                item.member_id = inferred
                 corrected_count += 1
             else:
-                # 추정이 불가능하면 임의 화자값을 만들지 않고 None으로 둔다.
-                item.speaker_id = None
+                # 추정이 불가능하면 임의 member_id를 만들지 않고 None으로 둔다.
+                item.member_id = None
                 unresolved_count += 1
 
     if corrected_count > 0:
         logger.warning(
-            "Normalized %s invalid timeline speaker_id values.",
+            "Normalized %s invalid timeline member_id values.",
             corrected_count,
         )
     if unresolved_count > 0:
         logger.warning(
-            "Could not infer %s timeline speaker_id values.",
+            "Could not infer %s timeline member_id values.",
             unresolved_count,
         )
 
@@ -641,7 +642,7 @@ async def extract_overall_analysis(
 async def extract_applications_only(
     segments: list[TranscribeSegment],
 ) -> MeetingAnalysisResult:
-    # applications/other_mentions만 추출 후 speaker_id 보정
+    # applications/other_mentions만 추출 후 member_id 보정
     stt_data = [segment.model_dump(mode="json") for segment in segments]
     prompt = _build_applications_prompt(stt_data)
     parsed = await _request_gemini_json(prompt, "Gemini 적용사항 추출")
@@ -653,7 +654,7 @@ async def extract_applications_only(
             other_mentions=applications_result.other_mentions,
         )
         _normalize_application_reason_outputs(result)
-        _normalize_timeline_speaker_ids(result, segments)
+        _normalize_timeline_member_ids(result, segments)
         return result
     except Exception as e:
         raise AppServiceError(

--- a/app/domains/transcribe/router.py
+++ b/app/domains/transcribe/router.py
@@ -100,7 +100,7 @@ SPRING_ASYNC_GUIDE = (
 )
 SPRING_APPLICATION_FAQ = (
     "팀 공유 FAQ:\n"
-    "- timeline.speaker_id는 null일 수 있습니다. "
+    "- timeline.member_id는 null일 수 있습니다. "
     "짧은 응답어/모호 발화에서 오탐을 피하기 위한 설계입니다.\n"
     "- summary_ready 단계의 application_titles는 임시값일 수 있으며, "
     "completed에서 최종 동기화됩니다.\n"
@@ -290,7 +290,7 @@ async def _run_transcribe_application_run(
                                             {
                                                 "timestamp": "00:09:40",
                                                 "step": "적용합의",
-                                                "speaker_id": "Speaker 0",
+                                                "member_id": 1,
                                                 "content": (
                                                     "ApiErrorCodeExample 어노테이션을 "
                                                     "추가하기로 합의함"
@@ -644,7 +644,7 @@ async def create_transcribe_application_run(
                                                 {
                                                     "timestamp": "00:03:12",
                                                     "step": "이슈제기",
-                                                    "speaker_id": "Speaker 0",
+                                                    "member_id": 1,
                                                     "content": (
                                                         "Swagger에서 에러 응답 예시가 "
                                                         "부족하다는 문제가 제기됨"
@@ -657,7 +657,7 @@ async def create_transcribe_application_run(
                                                 {
                                                     "timestamp": "00:06:20",
                                                     "step": "대안논의",
-                                                    "speaker_id": "Speaker 1",
+                                                    "member_id": 2,
                                                     "content": (
                                                         "어노테이션 기반 예시 "
                                                         "문서화가 논의됨"
@@ -670,7 +670,7 @@ async def create_transcribe_application_run(
                                                 {
                                                     "timestamp": "00:09:40",
                                                     "step": "적용합의",
-                                                    "speaker_id": "Speaker 0",
+                                                    "member_id": 1,
                                                     "content": (
                                                         "ApiErrorCodeExample "
                                                         "어노테이션을 "

--- a/tests/test_application_commit_matching.py
+++ b/tests/test_application_commit_matching.py
@@ -468,9 +468,9 @@ class TestCommitAnalyzeHashMetadata:
 
         assert response.result.commit_id == 1
         task = background_tasks.tasks[0]
-        assert task.args[0] == 1
-        assert task.args[1] == "b8fd9ad"
-        assert task.args[2] == 1
+        assert task.kwargs["commit_hash"] == "b8fd9ad"
+        assert task.kwargs["repository_id"] == 1
+        assert task.kwargs["commit_id"] == 1
 
     @pytest.mark.asyncio
     async def test_generate_embedding_text_stores_commit_hash_metadata(self):
@@ -502,16 +502,16 @@ class TestCommitAnalyzeHashMetadata:
             ),
         ):
             await generate_embedding_text(
-                1,
-                "b8fd9ad",
-                1,
-                "feat: API 구현",
-                [
+                commit_hash="b8fd9ad",
+                repository_id=1,
+                message="feat: API 구현",
+                changed_file_list=[
                     ChangedFile(
                         file_name="app/domains/api.py",
                         changed_code="+def handler():\n+    return True",
                     )
                 ],
+                commit_id=1,
             )
 
         _, kwargs = collection.upsert.call_args

--- a/tests/test_timeline_member_id.py
+++ b/tests/test_timeline_member_id.py
@@ -1,0 +1,87 @@
+from app.domains.meeting_analysis.schemas import (
+    Application,
+    ApplicationTimelineItem,
+    MeetingAnalysisResult,
+)
+from app.domains.meeting_analysis.services.extraction import (
+    APPLICATION_POLICY_PROMPT,
+    APPLICATIONS_ONLY_PROMPT,
+    _normalize_timeline_member_ids,
+)
+from app.domains.transcribe.schemas import TranscribeSegment
+
+
+class TestTimelineMemberId:
+    def test_timeline_prompt_uses_member_id_not_legacy_speaker_field(self):
+        prompt = f"{APPLICATION_POLICY_PROMPT}\n{APPLICATIONS_ONLY_PROMPT}"
+
+        assert '"member_id": 1' in prompt
+        assert "speaker" + "_id" not in prompt
+
+    def test_timeline_member_id_is_inferred_from_transcript_segment(self):
+        result = MeetingAnalysisResult(
+            applications=[
+                Application(
+                    application_title="Swagger 에러 응답 예시 문서화",
+                    application_reasons=[],
+                    timeline=[
+                        ApplicationTimelineItem(
+                            timestamp="00:00:03",
+                            step="적용합의",
+                            member_id=None,
+                            content="ApiErrorCodeExample 추가 합의",
+                            utterance="ApiErrorCodeExample을 추가하는 걸로 하죠.",
+                        )
+                    ],
+                )
+            ]
+        )
+        segments = [
+            TranscribeSegment(
+                message_id=1,
+                speaker="김준용",
+                member_id=7,
+                start_time="00:00:00",
+                end_time="00:00:05",
+                text="ApiErrorCodeExample을 추가하는 걸로 하죠.",
+                is_final=True,
+            )
+        ]
+
+        _normalize_timeline_member_ids(result, segments)
+
+        assert result.applications[0].timeline[0].member_id == 7
+
+    def test_timeline_member_id_is_null_when_transcript_has_no_member_id(self):
+        result = MeetingAnalysisResult(
+            applications=[
+                Application(
+                    application_title="STT 정확도 개선",
+                    application_reasons=[],
+                    timeline=[
+                        ApplicationTimelineItem(
+                            timestamp="00:00:03",
+                            step="이슈제기",
+                            member_id=999,
+                            content="전사 정확도 개선 필요성 제기",
+                            utterance="전사 정확도를 개선해야 합니다.",
+                        )
+                    ],
+                )
+            ]
+        )
+        segments = [
+            TranscribeSegment(
+                message_id=1,
+                speaker="Speaker 0",
+                member_id=None,
+                start_time="00:00:00",
+                end_time="00:00:05",
+                text="전사 정확도를 개선해야 합니다.",
+                is_final=True,
+            )
+        ]
+
+        _normalize_timeline_member_ids(result, segments)
+
+        assert result.applications[0].timeline[0].member_id is None


### PR DESCRIPTION
## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요. -->

적용사항 타임라인의 화자 필드를 STT 화자 라벨(`Speaker N`)이 아닌 Spring memberId 기준으로 변경했습니다.

## 📄 작업 내용
- 적용사항 타임라인 DTO 변경
  - `timeline[].speaker_id` 제거
  - `timeline[].member_id: int | null` 추가
- 회의 분석 프롬프트 변경
  - timeline 출력 구조를 `speaker_id` → `member_id` 기준으로 수정
  - `member_id`는 전사 세그먼트의 `member_id` 값을 사용하도록 명시
- 타임라인 화자 보정 로직 변경
  - 기존 STT speaker label 보정 대신 `timestamp + utterance` 기준으로 전사 세그먼트를 찾아 `member_id`를 주입
  - 매칭 실패 또는 live_messages 미전달 시 `member_id: null` 반환
- Swagger 예시 및 설명 수정
  - `/api/meeting-analysis/extract`
  - `/api/transcribe/applications`
  - `/api/transcribe/applications/runs/{run_id}`
- 관련 테스트 추가
  - timeline 프롬프트가 `member_id` 기준인지 검증
  - 전사 세그먼트의 `member_id`가 timeline에 보정되는지 검증
  - member_id 매칭 실패 시 `null` 처리 검증
- 기존 커밋 분석 테스트를 현재 `generate_embedding_text` 호출 방식에 맞게 정리

## 📌 관련 이슈
- close #34

## 🔌 API 변경사항 (해당 시)

### 변경된 응답 필드

기존:

```json
{
  "timestamp": "00:06:20",
  "step": "대안논의",
  "speaker_id": "Speaker 1",
  "content": "어노테이션 기반 예시 문서화가 논의됨",
  "utterance": "어노테이션으로 예시를 붙이면 관리하기 좋겠습니다."
}
```

변경후:
```json
{
  "timestamp": "00:06:20",
  "step": "대안논의",
  "member_id": 2,
  "content": "어노테이션 기반 예시 문서화가 논의됨",
  "utterance": "어노테이션으로 예시를 붙이면 관리하기 좋겠습니다."
}
```
### Spring 연동 주의사항
Spring DTO에서 timeline.speakerId 또는 timeline.speaker_id를 읽고 있다면 timeline.memberId 또는 timeline.member_id로 변경해야 합니다.
member_id는 Spring이 live_messages[].fromMemberId로 전달한 값을 기반으로 매칭됩니다.
live_messages가 없거나 매칭 신뢰도가 낮으면 member_id는 null일 수 있습니다.
전사 결과 transcript_segments[].member_id는 기존처럼 유지됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 회의 분석 타임라인의 식별자 필드를 `speaker_id`에서 `member_id`로 변경했습니다.
  * 타임라인 항목의 멤버 ID 추론 및 정규화 로직을 개선했습니다.

* **문서**
  * API 응답 예시 및 설명을 업데이트하여 `member_id` 필드 및 null 가능성을 명확히 했습니다.

* **테스트**
  * 타임라인 멤버 ID 처리 검증을 위한 새로운 테스트 스위트를 추가했습니다.
  * 기존 테스트를 최신 로직에 맞게 업데이트했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhyLog-App/Whylog-AI/pull/35)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->