### PR TITLE
[docs] 회의 분석 재추출 요청 예시 member_id 누락 수정

### DIFF
--- a/app/domains/meeting_analysis/router.py
+++ b/app/domains/meeting_analysis/router.py
@@ -167,7 +167,8 @@ async def extract_meeting_analysis_from_transcript(
                         "transcript_segments": [
                             {
                                 "message_id": 1,
-                                "speaker": "Speaker 0",
+                                "speaker": "김준용",
+                                "member_id": 1,
                                 "start_time": "00:00:00",
                                 "end_time": "00:00:03",
                                 "text": (


### PR DESCRIPTION
## ✨ 작업 개요
`/api/meeting-analysis/extract` Swagger 요청 예시가 실제 전사 응답 DTO와 다르게 표시되던 부분을 수정했습니다.

## 📄 작업 내용
- `transcript_segments` 요청 예시에 `member_id` 추가
- 예시의 `speaker` 값을 `Speaker 0`에서 실제 이름 형태로 변경

## 📌 관련 이슈
- close #36 

## 🔌 API 변경사항 (해당 시)
없음. Swagger 예시만 수정했습니다.

## ✅ 테스트
```bash
uv run ruff check app/domains/meeting_analysis/router.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 문서

* 미팅 분석 추출 엔드포인트의 API 요청 예시가 업데이트되었습니다. 예시 데이터가 더욱 현실적인 샘플로 개선되어 API 활용 시 참고도가 높아졌습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhyLog-App/Whylog-AI/pull/37)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->