### PR TITLE
[fix/#38] 짧은 회의 memberId 매칭 완화

### DIFF
--- a/app/domains/transcribe/services/live_transcript_merge.py
+++ b/app/domains/transcribe/services/live_transcript_merge.py
@@ -34,6 +34,7 @@ MIN_CORRECTION_SCORE = 0.72
 MIN_SPEAKER_VOTES = 2
 MIN_SPEAKER_SHARE = 0.6
 MIN_SPEAKER_AVG_SCORE = 0.6
+MIN_DOMINANT_MEMBER_SHARE = 0.75
 TIME_WINDOW_SECONDS = 12.0
 _live_messages_adapter = TypeAdapter(list[LiveTranscriptMessage])
 
@@ -84,7 +85,7 @@ def merge_live_transcript(
         return segments
 
     matches = _match_segments_to_live_messages(segments, live_entries)
-    speaker_mapping = _resolve_speaker_mapping(segments, matches)
+    speaker_mapping = _resolve_speaker_mapping(segments, live_entries, matches)
     return _apply_matches(segments, matches, speaker_mapping)
 
 
@@ -173,6 +174,7 @@ def _score_match(
 
 def _resolve_speaker_mapping(
     segments: list[TranscribeSegment],
+    live_entries: list[_LiveEntry],
     matches: dict[int, _SegmentMatch],
 ) -> dict[str, tuple[int, str, float]]:
     votes: dict[str, dict[tuple[int, str], list[float]]] = defaultdict(
@@ -220,7 +222,67 @@ def _resolve_speaker_mapping(
             avg_score,
         )
 
+    _apply_single_speaker_dominant_member_fallback(
+        resolved=resolved,
+        segments=segments,
+        live_entries=live_entries,
+        matches=matches,
+    )
     return resolved
+
+
+def _apply_single_speaker_dominant_member_fallback(
+    resolved: dict[str, tuple[int, str, float]],
+    segments: list[TranscribeSegment],
+    live_entries: list[_LiveEntry],
+    matches: dict[int, _SegmentMatch],
+) -> None:
+    # 짧은 회의에서는 텍스트 유사도 투표가 부족할 수 있어
+    # 단일 화자/단일 멤버 흐름을 보강한다.
+    speakers = {segment.speaker for segment in segments if segment.speaker}
+    if len(speakers) != 1:
+        return
+
+    speaker = next(iter(speakers))
+    if speaker in resolved:
+        return
+    if not live_entries:
+        return
+    if not any(not live.is_ambiguous for live in live_entries):
+        return
+
+    member_votes: dict[tuple[int, str], int] = defaultdict(int)
+    for live in live_entries:
+        member_id = live.message.from_member_id
+        member_name = live.message.from_name or ""
+        if member_id is None or not member_name:
+            continue
+        member_votes[(member_id, member_name)] += 1
+    if not member_votes:
+        return
+
+    best_member, best_count = max(member_votes.items(), key=lambda item: item[1])
+    share = best_count / len(live_entries)
+    if share < MIN_DOMINANT_MEMBER_SHARE:
+        return
+
+    match_scores = [
+        match.score
+        for segment_index, match in matches.items()
+        if 0 <= segment_index < len(segments)
+        and segments[segment_index].speaker == speaker
+        and match.live.message.from_member_id == best_member[0]
+    ]
+    confidence = sum(match_scores) / len(match_scores) if match_scores else share
+    resolved[speaker] = (best_member[0], best_member[1], confidence)
+    logger.info(
+        "speaker mapped by dominant-member fallback: "
+        "%s -> %s(member_id=%s, confidence=%.2f)",
+        speaker,
+        best_member[1],
+        best_member[0],
+        confidence,
+    )
 
 
 def _apply_matches(

--- a/app/domains/transcribe/services/live_transcript_merge.py
+++ b/app/domains/transcribe/services/live_transcript_merge.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import re
-from collections import defaultdict
+from collections import Counter, defaultdict
 from dataclasses import dataclass
 from difflib import SequenceMatcher
 from string import punctuation
@@ -82,10 +82,23 @@ def merge_live_transcript(
     # STT 결과와 WebSocket 발화 로그를 매칭해 최종 전사를 보강
     live_entries = _prepare_live_entries(live_messages)
     if not segments or not live_entries:
+        logger.info(
+            "live transcript merge skipped: "
+            "segments=%s live_messages=%s live_entries=%s",
+            len(segments),
+            len(live_messages),
+            len(live_entries),
+        )
         return segments
 
     matches = _match_segments_to_live_messages(segments, live_entries)
     speaker_mapping = _resolve_speaker_mapping(segments, live_entries, matches)
+    _log_merge_result(
+        segments=segments,
+        live_entries=live_entries,
+        matches=matches,
+        speaker_mapping=speaker_mapping,
+    )
     return _apply_matches(segments, matches, speaker_mapping)
 
 
@@ -93,16 +106,21 @@ def _prepare_live_entries(
     live_messages: list[LiveTranscriptMessage],
 ) -> list[_LiveEntry]:
     entries: list[_LiveEntry] = []
+    skipped: Counter[str] = Counter()
     for index, message in enumerate(live_messages):
         if message.type.upper() != "TEXT":
+            skipped["non_text_type"] += 1
             continue
         text = (message.text or "").strip()
         if not text:
+            skipped["empty_text"] += 1
             continue
         if message.from_member_id is None or not message.from_name:
+            skipped["missing_member"] += 1
             continue
         normalized_text = _normalize_text(text)
         if not normalized_text:
+            skipped["empty_normalized_text"] += 1
             continue
         entries.append(
             _LiveEntry(
@@ -113,6 +131,13 @@ def _prepare_live_entries(
                 is_ambiguous=_is_ambiguous_text(normalized_text),
             )
         )
+    logger.info(
+        "live transcript messages prepared: raw=%s prepared=%s skipped=%s samples=%s",
+        len(live_messages),
+        len(entries),
+        dict(skipped),
+        [_live_entry_debug_sample(entry) for entry in entries[:5]],
+    )
     return entries
 
 
@@ -153,6 +178,13 @@ def _match_segments_to_live_messages(
             matches[segment_index] = best_match
             used_live_indexes.add(best_match.live.index)
 
+    logger.info(
+        "live transcript segment matching completed: "
+        "segments=%s live_entries=%s matches=%s",
+        len(segments),
+        len(live_entries),
+        len(matches),
+    )
     return matches
 
 
@@ -245,10 +277,16 @@ def _apply_single_speaker_dominant_member_fallback(
 
     speaker = next(iter(speakers))
     if speaker in resolved:
+        logger.info(
+            "dominant-member fallback skipped: speaker already resolved speaker=%s",
+            speaker,
+        )
         return
     if not live_entries:
+        logger.info("dominant-member fallback skipped: no live entries")
         return
     if not any(not live.is_ambiguous for live in live_entries):
+        logger.info("dominant-member fallback skipped: all live entries are ambiguous")
         return
 
     member_votes: dict[tuple[int, str], int] = defaultdict(int)
@@ -259,11 +297,20 @@ def _apply_single_speaker_dominant_member_fallback(
             continue
         member_votes[(member_id, member_name)] += 1
     if not member_votes:
+        logger.info("dominant-member fallback skipped: no member votes")
         return
 
     best_member, best_count = max(member_votes.items(), key=lambda item: item[1])
     share = best_count / len(live_entries)
     if share < MIN_DOMINANT_MEMBER_SHARE:
+        logger.info(
+            "dominant-member fallback skipped: dominant share too low "
+            "best_member_id=%s share=%.2f threshold=%.2f votes=%s",
+            best_member[0],
+            share,
+            MIN_DOMINANT_MEMBER_SHARE,
+            {member_id: count for (member_id, _), count in member_votes.items()},
+        )
         return
 
     match_scores = [
@@ -283,6 +330,73 @@ def _apply_single_speaker_dominant_member_fallback(
         best_member[0],
         confidence,
     )
+
+
+def _log_merge_result(
+    segments: list[TranscribeSegment],
+    live_entries: list[_LiveEntry],
+    matches: dict[int, _SegmentMatch],
+    speaker_mapping: dict[str, tuple[int, str, float]],
+) -> None:
+    null_speakers = sorted(
+        {
+            segment.speaker
+            for segment in segments
+            if segment.speaker and segment.speaker not in speaker_mapping
+        }
+    )
+    logger.info(
+        "live transcript merge result: segments=%s live_entries=%s matches=%s "
+        "mapped_speakers=%s unmapped_speakers=%s match_samples=%s",
+        len(segments),
+        len(live_entries),
+        len(matches),
+        {
+            speaker: {"member_id": member_id, "member_name": member_name}
+            for speaker, (member_id, member_name, _) in speaker_mapping.items()
+        },
+        null_speakers,
+        [_match_debug_sample(segments, match) for match in list(matches.values())[:5]],
+    )
+
+
+def _live_entry_debug_sample(entry: _LiveEntry) -> dict[str, object]:
+    return {
+        "index": entry.index,
+        "meeting_id": entry.message.meeting_id,
+        "member_id": entry.message.from_member_id,
+        "member_name": entry.message.from_name,
+        "timestamp": entry.message.timestamp,
+        "seconds": entry.seconds,
+        "ambiguous": entry.is_ambiguous,
+        "text": _text_preview(entry.message.text),
+    }
+
+
+def _match_debug_sample(
+    segments: list[TranscribeSegment],
+    match: _SegmentMatch,
+) -> dict[str, object]:
+    segment = segments[match.segment_index]
+    return {
+        "segment_index": match.segment_index,
+        "message_id": segment.message_id,
+        "speaker": segment.speaker,
+        "segment_time": segment.start_time,
+        "live_index": match.live.index,
+        "live_member_id": match.live.message.from_member_id,
+        "score": round(match.score, 3),
+        "text_similarity": round(match.text_similarity, 3),
+        "segment_text": _text_preview(segment.text),
+        "live_text": _text_preview(match.live.message.text),
+    }
+
+
+def _text_preview(value: str | None, limit: int = 40) -> str:
+    normalized = " ".join((value or "").split())
+    if len(normalized) <= limit:
+        return normalized
+    return f"{normalized[:limit]}..."
 
 
 def _apply_matches(

--- a/tests/test_live_transcript_merge.py
+++ b/tests/test_live_transcript_merge.py
@@ -138,6 +138,75 @@ def test_merge_live_transcript_keeps_stt_when_only_ambiguous_short_messages_exis
     assert merged[1].member_id is None
 
 
+def test_merge_live_transcript_maps_single_speaker_to_dominant_live_member():
+    segments = [
+        _segment(1, "Speaker 0", "00:00:00", "헤이 시작 오늘은 무슨 게임을 시작할까요"),
+        _segment(2, "Speaker 0", "00:00:06", "게임하지 말고 잡시다"),
+        _segment(3, "Speaker 0", "00:00:13", "바이바이"),
+    ]
+    live_messages = [
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=143,
+            fromMemberId=9,
+            fromName="김준용",
+            timestamp="00:00:00",
+            text="회의 시작 오늘은 무슨 얘기를 할까요",
+        ),
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=143,
+            fromMemberId=9,
+            fromName="김준용",
+            timestamp="00:00:06",
+            text="게임하지 말고 잡시다",
+        ),
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=143,
+            fromMemberId=9,
+            fromName="김준용",
+            timestamp="00:00:13",
+            text="바이바이",
+        ),
+    ]
+
+    merged = merge_live_transcript(segments, live_messages)
+
+    assert [segment.member_id for segment in merged] == [9, 9, 9]
+    assert {segment.speaker for segment in merged} == {"김준용"}
+
+
+def test_merge_live_transcript_does_not_use_dominant_fallback_for_mixed_members():
+    segments = [
+        _segment(1, "Speaker 0", "00:00:00", "첫 번째 안건입니다"),
+        _segment(2, "Speaker 0", "00:00:06", "두 번째 안건입니다"),
+    ]
+    live_messages = [
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=143,
+            fromMemberId=9,
+            fromName="김준용",
+            timestamp="00:00:00",
+            text="완전히 다른 이야기입니다",
+        ),
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=143,
+            fromMemberId=10,
+            fromName="유상완",
+            timestamp="00:00:06",
+            text="또 다른 내용입니다",
+        ),
+    ]
+
+    merged = merge_live_transcript(segments, live_messages)
+
+    assert [segment.member_id for segment in merged] == [None, None]
+    assert {segment.speaker for segment in merged} == {"Speaker 0"}
+
+
 def test_merge_live_transcript_uses_text_and_order_when_timestamp_is_iso_string():
     segments = [
         _segment(1, "Speaker 0", "00:00:01", "안녀 하세요"),


### PR DESCRIPTION
## ✨ 작업 개요
짧은 회의나 짧은 발화에서 WebSocket 발화 로그가 전달되어도 STT 텍스트 유사도 투표가 부족해 `member_id`가 전부 `null`로 남는 문제를 보완했습니다.

## 📄 작업 내용
- 단일 STT speaker + 단일 member 중심 live_messages인 경우 memberId fallback 매핑 추가
- 특정 memberId가 live_messages의 75% 이상을 차지할 때만 fallback 적용
- 전부 짧고 모호한 발화(예: 네/응/음)만 있는 경우는 오탐 방지를 위해 fallback 미적용
- 텍스트 보정은 기존처럼 높은 신뢰도 조건에서만 수행
- 단일 멤버 fallback 성공/혼합 멤버 fallback 차단 테스트 추가

## 📌 관련 이슈
- close #38

## 🔌 API 변경사항 (해당 시)
없음. 기존 `transcript_segments[].member_id` 보강 로직만 완화했습니다.

## ✅ 테스트
```bash
uv run ruff check app tests services schemas routers utils
uv run pytest
```

결과:

```text
All checks passed!
65 passed
```

## 💬 기타 사항
- memberId 매핑은 완화했지만, 전사 텍스트 덮어쓰기는 기존 신뢰도 기준을 유지했습니다.
- 여러 멤버가 섞인 경우에는 fallback을 적용하지 않고 기존처럼 `member_id: null`을 유지합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 라이브 트랜스크립트 병합 시 발언자-회원 매핑 정확도 개선
  * 텍스트 기반 식별 부족 시 폴백 메커니즘 추가
  * 단일 발언자 상황에서 우세 회원 분석을 통한 신뢰도 기반 할당 지원

* **테스트**
  * 단일 발언자 시나리오 검증 테스트 추가
  * 혼합 회원 환경에서 폴백 미적용 검증 테스트 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhyLog-App/Whylog-AI/pull/39)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->