### PR TITLE
[fix/#40] 커밋 매칭 후보를 팀 레포 목록으로 제한

### DIFF
--- a/app/domains/commit/router.py
+++ b/app/domains/commit/router.py
@@ -261,7 +261,10 @@ async def get_commit_analyze_run(
     summary="적용사항-커밋 추천 매칭",
     description=(
         "회의 적용사항(application 단위)에 대해 "
-        "커밋 임베딩 후보를 유사도 기반으로 추천합니다.\n\n"
+        "커밋 임베딩 후보를 유사도 기반으로 추천합니다.\n"
+        "`repository_ids`에는 팀에 등록된 레포 ID 목록을 전달하며, "
+        "해당 목록 밖의 커밋은 후보에서 제외합니다. "
+        "`top_k`는 레포별 개수가 아니라 적용사항별 최대 추천 개수입니다.\n\n"
         "점수 정책(100점):\n"
         "- 의미 유사성 50\n"
         "- 기술 키워드 일치도 30\n"
@@ -282,7 +285,7 @@ async def get_commit_analyze_run(
                         "message": "적용사항-커밋 추천 분석이 완료되었습니다.",
                         "result": {
                             "meeting_id": "meeting-123",
-                            "repository_id": 1,
+                            "repository_ids": [1, 2, 3],
                             "total_applications": 1,
                             "matched_applications": 1,
                             "applications": [

--- a/app/domains/commit/schemas.py
+++ b/app/domains/commit/schemas.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field
 
@@ -117,10 +117,12 @@ class ApplicationCommitMatchRequest(BaseModel):
         description="적용사항 임베딩을 조회할 회의 ID",
         pattern=r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$",
     )
-    repository_id: int | None = Field(
-        default=None,
-        ge=0,
-        description="레포지토리 ID (선택, 미지정 시 전체 후보 조회)",
+    repository_ids: list[Annotated[int, Field(ge=0)]] = Field(
+        min_length=1,
+        description=(
+            "매칭 후보로 사용할 Spring 레포지토리 ID 목록. "
+            "팀에 등록된 레포 목록을 모두 전달합니다."
+        ),
     )
     top_k: int = Field(
         default=5,
@@ -167,7 +169,9 @@ class ApplicationCommitMatchItem(BaseModel):
 
 class ApplicationCommitMatchResponse(BaseModel):
     meeting_id: str = Field(description="회의 ID")
-    repository_id: int | None = Field(default=None, description="레포지토리 ID 필터")
+    repository_ids: list[int] = Field(
+        description="매칭 후보로 사용한 레포지토리 ID 목록"
+    )
     total_applications: int = Field(description="조회된 적용사항 문서 수")
     matched_applications: int = Field(description="추천 결과가 존재하는 적용사항 수")
     applications: list[ApplicationCommitMatchItem] = Field(

--- a/app/domains/commit/services/matching.py
+++ b/app/domains/commit/services/matching.py
@@ -230,7 +230,7 @@ async def _query_commit_candidates(
     query_embedding: list[float],
     *,
     n_results: int,
-    repository_id: int | None,
+    repository_ids: list[int],
 ) -> dict[str, Any]:
     collection = get_commit_collection()
     query_kwargs: dict[str, Any] = {
@@ -238,8 +238,10 @@ async def _query_commit_candidates(
         "n_results": n_results,
         "include": ["documents", "metadatas", "distances"],
     }
-    if repository_id is not None:
-        query_kwargs["where"] = {"repository_id": repository_id}
+    if len(repository_ids) == 1:
+        query_kwargs["where"] = {"repository_id": repository_ids[0]}
+    else:
+        query_kwargs["where"] = {"repository_id": {"$in": repository_ids}}
 
     try:
         return await asyncio.to_thread(
@@ -353,7 +355,7 @@ async def match_applications_with_commits(
     if not application_entries:
         return ApplicationCommitMatchResponse(
             meeting_id=payload.meeting_id,
-            repository_id=payload.repository_id,
+            repository_ids=payload.repository_ids,
             total_applications=0,
             matched_applications=0,
             applications=[],
@@ -363,6 +365,7 @@ async def match_applications_with_commits(
     matched_by_application: dict[int, dict[str, MatchRecord]] = {
         idx: {} for idx in range(len(application_entries))
     }
+    repository_id_set = set(payload.repository_ids)
 
     for application_index, application in enumerate(application_entries):
         if not application.embedding:
@@ -375,7 +378,7 @@ async def match_applications_with_commits(
         query_result = await _query_commit_candidates(
             application.embedding,
             n_results=pool_size,
-            repository_id=payload.repository_id,
+            repository_ids=payload.repository_ids,
         )
 
         ids_nested = query_result.get("ids") or [[]]
@@ -393,10 +396,7 @@ async def match_applications_with_commits(
             commit_repository_id = _first_int(metadata.get("repository_id"))
 
             # Chroma where 필터 이후에도 metadata 불일치에 대비해 한 번 더 검증한다.
-            if (
-                payload.repository_id is not None
-                and commit_repository_id != payload.repository_id
-            ):
+            if commit_repository_id not in repository_id_set:
                 continue
 
             commit_document = docs[idx] if idx < len(docs) and docs[idx] else ""
@@ -458,7 +458,7 @@ async def match_applications_with_commits(
 
     return ApplicationCommitMatchResponse(
         meeting_id=payload.meeting_id,
-        repository_id=payload.repository_id,
+        repository_ids=payload.repository_ids,
         total_applications=len(application_entries),
         matched_applications=matched_applications,
         applications=application_items,

--- a/app/domains/commit/services/matching.py
+++ b/app/domains/commit/services/matching.py
@@ -361,7 +361,7 @@ async def match_applications_with_commits(
             applications=[],
         )
 
-    pool_size = min(100, max(payload.top_k, payload.top_k * 5))
+    pool_size = min(100, payload.top_k * 5)
     matched_by_application: dict[int, dict[str, MatchRecord]] = {
         idx: {} for idx in range(len(application_entries))
     }

--- a/tests/test_application_commit_matching.py
+++ b/tests/test_application_commit_matching.py
@@ -222,6 +222,63 @@ class TestApplicationCommitMatchingService:
         }
 
     @pytest.mark.asyncio
+    async def test_filters_candidate_outside_requested_repository_ids(self):
+        application_collection = MagicMock()
+        application_collection.get.return_value = {
+            "ids": ["meeting-123_application0"],
+            "documents": [
+                "title: Redis 도입 | text: 적용사항: notification redis 도입"
+            ],
+            "metadatas": [{"application_title": "notification redis 도입"}],
+            "embeddings": [[0.1, 0.2]],
+        }
+
+        commit_collection = MagicMock()
+        commit_collection.query.return_value = {
+            "ids": [["commit_99"]],
+            "documents": [
+                [
+                    (
+                        "변경요약: redis queue 도입 | 기술키워드: redis "
+                        "| 변경방향: add | 파일맥락: notification"
+                    )
+                ]
+            ],
+            "metadatas": [
+                [
+                    {
+                        "commit_ref": "c99",
+                        "commit_hash": "h99",
+                        "repository_id": 99,
+                        "direction_primary": "add",
+                        "direction_multi_csv": "add",
+                        "tech_keywords_csv": "redis",
+                        "module_tags_csv": "notification",
+                        "commit_message": "feat: introduce redis",
+                    }
+                ]
+            ],
+            "distances": [[0.01]],
+        }
+
+        with (
+            patch(
+                "app.domains.commit.services.matching.get_application_collection",
+                return_value=application_collection,
+            ),
+            patch(
+                "app.domains.commit.services.matching.get_commit_collection",
+                return_value=commit_collection,
+            ),
+        ):
+            result = await match_applications_with_commits(
+                ApplicationCommitMatchRequest(**_build_match_payload())
+            )
+
+        assert result.matched_applications == 0
+        assert result.applications[0].recommended_commits == []
+
+    @pytest.mark.asyncio
     async def test_opposite_direction_candidate_is_not_matched(self):
         application_collection = MagicMock()
         application_collection.get.return_value = {
@@ -416,6 +473,28 @@ class TestApplicationCommitMatchingEndpoint:
         assert body["result"]["repository_ids"] == [1]
         assert body["result"]["applications"][0]["application_id"] == 101
 
+    def test_match_endpoint_echoes_multiple_repository_ids(self):
+        mock_result = ApplicationCommitMatchResponse(
+            meeting_id="meeting-123",
+            repository_ids=[1, 2, 3],
+            total_applications=0,
+            matched_applications=0,
+            applications=[],
+        )
+        payload = _build_match_payload()
+        payload["repository_ids"] = [1, 2, 3]
+
+        with patch(
+            "app.domains.commit.router.match_applications_with_commits",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            response = self.client.post("/api/commit/match", json=payload)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["result"]["repository_ids"] == [1, 2, 3]
+
     def test_match_endpoint_validation_error(self):
         payload = _build_match_payload()
         payload["top_k"] = 0
@@ -430,6 +509,17 @@ class TestApplicationCommitMatchingEndpoint:
     def test_match_endpoint_requires_repository_ids(self):
         payload = _build_match_payload()
         payload["repository_ids"] = []
+
+        response = self.client.post("/api/commit/match", json=payload)
+
+        assert response.status_code == 422
+        body = response.json()
+        assert body["isSuccess"] is False
+        assert body["code"] == "COMMON_422"
+
+    def test_match_endpoint_requires_repository_ids_key(self):
+        payload = _build_match_payload()
+        del payload["repository_ids"]
 
         response = self.client.post("/api/commit/match", json=payload)
 

--- a/tests/test_application_commit_matching.py
+++ b/tests/test_application_commit_matching.py
@@ -24,7 +24,7 @@ from app.main import app
 def _build_match_payload() -> dict:
     return {
         "meeting_id": "meeting-123",
-        "repository_id": 1,
+        "repository_ids": [1],
         "top_k": 5,
     }
 
@@ -182,7 +182,7 @@ class TestApplicationCommitMatchingService:
         assert commit_collection.query.call_args.kwargs["where"] == {"repository_id": 1}
 
     @pytest.mark.asyncio
-    async def test_repository_none_queries_without_where_filter(self):
+    async def test_multiple_repository_ids_query_with_in_filter(self):
         application_collection = MagicMock()
         application_collection.get.return_value = {
             "ids": ["meeting-123_application0"],
@@ -200,7 +200,7 @@ class TestApplicationCommitMatchingService:
         }
 
         payload = _build_match_payload()
-        payload["repository_id"] = None
+        payload["repository_ids"] = [1, 2, 3]
 
         with (
             patch(
@@ -217,7 +217,9 @@ class TestApplicationCommitMatchingService:
             )
 
         commit_collection.query.assert_called_once()
-        assert "where" not in commit_collection.query.call_args.kwargs
+        assert commit_collection.query.call_args.kwargs["where"] == {
+            "repository_id": {"$in": [1, 2, 3]}
+        }
 
     @pytest.mark.asyncio
     async def test_opposite_direction_candidate_is_not_matched(self):
@@ -383,7 +385,7 @@ class TestApplicationCommitMatchingEndpoint:
     def test_match_endpoint_success(self):
         mock_result = ApplicationCommitMatchResponse(
             meeting_id="meeting-123",
-            repository_id=1,
+            repository_ids=[1],
             total_applications=1,
             matched_applications=1,
             applications=[
@@ -411,12 +413,23 @@ class TestApplicationCommitMatchingEndpoint:
         assert body["isSuccess"] is True
         assert body["code"] == "COMMIT_MATCH_200"
         assert body["result"]["meeting_id"] == "meeting-123"
-        assert body["result"]["repository_id"] == 1
+        assert body["result"]["repository_ids"] == [1]
         assert body["result"]["applications"][0]["application_id"] == 101
 
     def test_match_endpoint_validation_error(self):
         payload = _build_match_payload()
         payload["top_k"] = 0
+
+        response = self.client.post("/api/commit/match", json=payload)
+
+        assert response.status_code == 422
+        body = response.json()
+        assert body["isSuccess"] is False
+        assert body["code"] == "COMMON_422"
+
+    def test_match_endpoint_requires_repository_ids(self):
+        payload = _build_match_payload()
+        payload["repository_ids"] = []
 
         response = self.client.post("/api/commit/match", json=payload)
 


### PR DESCRIPTION
## ✨ 작업 개요
`/api/commit/match`가 팀에 등록된 레포 목록 안에서만 커밋 후보를 조회하도록 `repository_ids` 필수 배열 기준으로 변경했습니다.

## 📄 작업 내용
- 매칭 요청 DTO 변경
  - `repository_id` → `repository_ids`
  - 빈 배열 불가
- Chroma commit 후보 조회를 `repository_ids` 범위로 제한
- Chroma where 필터 이후 metadata `repository_id` 후검증 유지
- 매칭 응답에 `repository_ids` echo
- Swagger 예시/설명 수정
- 관련 테스트 갱신 및 보강

## 📌 관련 이슈
- close #40

## 🔌 API 변경사항 (해당 시)
기존:
```json
{
  "meeting_id": "meeting-123",
  "repository_id": 1,
  "top_k": 5
}
```

변경:
```json
{
  "meeting_id": "meeting-123",
  "repository_ids": [1, 2, 3],
  "top_k": 5
}
```

- `repository_ids`는 필수이며, 팀에 등록된 레포 ID 목록을 전달합니다.
- `top_k`는 repository별 개수가 아니라 `repository_ids` 전체 후보 중 적용사항별 최대 추천 개수입니다.

## 💬 기타 사항
- 다른 레포/팀 커밋이 후보에 섞이지 않도록 `repository_ids` 기준으로 후보 범위를 제한했습니다.
- 검증: `uv run ruff check app tests services schemas routers utils`, `uv run ruff format --check .`, `uv run pytest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 커밋 매칭 엔드포인트가 이제 여러 저장소에 대한 동시 검색을 지원합니다.
  * 요청 시 복수의 저장소 ID를 전달할 수 있게 되었습니다.

* **개선사항**
  * API 응답 형식이 업데이트되어 매칭된 저장소 목록을 더 명확하게 반환합니다.
  * 엔드포인트 문서가 저장소 ID 전달 규칙과 검색 결과 의미를 명시하도록 개선되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhyLog-App/Whylog-AI/pull/41)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->