### PR TITLE
[fix/#42] WebSocket 발화로그 기준 전사 보강

### DIFF
--- a/app/domains/meeting_analysis/services/extraction.py
+++ b/app/domains/meeting_analysis/services/extraction.py
@@ -80,6 +80,17 @@ NOUN_ENDING_REASON_RULE = [
     "   끝나는 서술형 문장은 절대 출력하지 않는다.",
     "5. 전체 문장을 설명하지 말고 짧은 근거 라벨처럼 작성한다.",
 ]
+CONCRETE_APPLICATION_RULE = [
+    "[적용사항 구체화 규칙 - 반드시 준수]",
+    "1. application_title은 주제명이 아니라 실제 실행/반영 단위로 작성한다.",
+    '2. 금지 예: "전사 품질 개선", "회의 분석 고도화", "데모 준비"',
+    '3. 허용 예: "WebSocket 발화로그 기준으로 STT 화자 보정 적용",',
+    '   "전시회 데모 시나리오를 5분 이내 흐름으로 재구성"',
+    "4. timeline의 적용합의 content도 구체적인 실행 문장으로 작성한다.",
+    "5. 적용합의 content는 무엇을 어떻게 반영할지 드러나야 한다.",
+    '6. "개선하기로 함", "논의하기로 함", "준비하기로 함"처럼',
+    "   대상/방법이 빠진 두루뭉술한 표현은 절대 사용하지 않는다.",
+]
 
 APPLICATION_POLICY_PROMPT = "\n".join(
     [
@@ -111,6 +122,7 @@ APPLICATION_POLICY_PROMPT = "\n".join(
         "3. 반드시 실제 발화(Utterance) 원문과 member_id를 포함한다.",
         "   member_id는 STT 데이터의 member_id 값을 사용하고, 없으면 null로 둔다.",
         "4. timeline의 content는 간략한 한 문장으로 작성한다.",
+        *CONCRETE_APPLICATION_RULE,
         "------------------------------------------------------------",
         "",
         "[출력 JSON 구조]:",
@@ -197,6 +209,7 @@ APPLICATIONS_ONLY_PROMPT = "\n".join(
         "2. 실제 발화 원문과 member_id를 포함한다.",
         "3. member_id는 STT 데이터의 member_id 값을 사용하고, 없으면 null로 둔다.",
         "4. content는 간략한 한 문장으로 작성한다.",
+        *CONCRETE_APPLICATION_RULE,
         "",
         "[출력 JSON 구조]",
         "{",

--- a/app/domains/transcribe/services/live_transcript_merge.py
+++ b/app/domains/transcribe/services/live_transcript_merge.py
@@ -35,6 +35,7 @@ MIN_SPEAKER_VOTES = 2
 MIN_SPEAKER_SHARE = 0.6
 MIN_SPEAKER_AVG_SCORE = 0.6
 MIN_DOMINANT_MEMBER_SHARE = 0.75
+MIN_TEXT_SIMILARITY_FOR_MATCH = 0.6
 TIME_WINDOW_SECONDS = 12.0
 _live_messages_adapter = TypeAdapter(list[LiveTranscriptMessage])
 
@@ -99,7 +100,12 @@ def merge_live_transcript(
         matches=matches,
         speaker_mapping=speaker_mapping,
     )
-    return _apply_matches(segments, matches, speaker_mapping)
+    return _apply_matches(
+        segments,
+        live_entries,
+        matches,
+        speaker_mapping,
+    )
 
 
 def _prepare_live_entries(
@@ -145,38 +151,55 @@ def _match_segments_to_live_messages(
     segments: list[TranscribeSegment],
     live_entries: list[_LiveEntry],
 ) -> dict[int, _SegmentMatch]:
-    matches: dict[int, _SegmentMatch] = {}
-    used_live_indexes: set[int] = set()
-
+    candidates: list[_SegmentMatch] = []
     for segment_index, segment in enumerate(segments):
         segment_seconds = _parse_time_to_seconds(segment.start_time)
         segment_text = _normalize_text(segment.text)
         if not segment_text:
             continue
 
-        best_match: _SegmentMatch | None = None
         for live in live_entries:
-            if live.index in used_live_indexes:
-                continue
             score, text_similarity = _score_match(
                 segment_index=segment_index,
                 segment_seconds=segment_seconds,
                 segment_text=segment_text,
                 live=live,
             )
+            if (
+                not live.is_ambiguous
+                and text_similarity < MIN_TEXT_SIMILARITY_FOR_MATCH
+            ):
+                continue
             if score < MIN_MATCH_SCORE:
                 continue
-            if best_match is None or score > best_match.score:
-                best_match = _SegmentMatch(
+            candidates.append(
+                _SegmentMatch(
                     segment_index=segment_index,
                     live=live,
                     score=score,
                     text_similarity=text_similarity,
                 )
+            )
 
-        if best_match is not None:
-            matches[segment_index] = best_match
-            used_live_indexes.add(best_match.live.index)
+    matches: dict[int, _SegmentMatch] = {}
+    used_segments: set[int] = set()
+    used_live_indexes: set[int] = set()
+    for candidate in sorted(
+        candidates,
+        key=lambda match: (
+            match.score,
+            match.text_similarity,
+            -abs(match.segment_index - match.live.index),
+        ),
+        reverse=True,
+    ):
+        if candidate.segment_index in used_segments:
+            continue
+        if candidate.live.index in used_live_indexes:
+            continue
+        matches[candidate.segment_index] = candidate
+        used_segments.add(candidate.segment_index)
+        used_live_indexes.add(candidate.live.index)
 
     logger.info(
         "live transcript segment matching completed: "
@@ -401,20 +424,42 @@ def _text_preview(value: str | None, limit: int = 40) -> str:
 
 def _apply_matches(
     segments: list[TranscribeSegment],
+    live_entries: list[_LiveEntry],
     matches: dict[int, _SegmentMatch],
     speaker_mapping: dict[str, tuple[int, str, float]],
 ) -> list[TranscribeSegment]:
-    corrected: list[TranscribeSegment] = []
+    if not matches:
+        live_only_segments = _build_live_only_segments(live_entries)
+        if live_only_segments:
+            logger.info(
+                "live transcript merge using WebSocket-only fallback: "
+                "segments=%s live_entries=%s",
+                len(segments),
+                len(live_entries),
+            )
+            return _renumber_segments(live_only_segments)
+        return segments
+
+    corrected: list[tuple[float, int, TranscribeSegment]] = []
+    used_live_indexes = {match.live.index for match in matches.values()}
     for segment_index, segment in enumerate(segments):
         update: dict[str, object] = {}
 
-        speaker_match = speaker_mapping.get(segment.speaker)
-        if speaker_match:
-            member_id, member_name, _ = speaker_match
-            update["speaker"] = member_name
-            update["member_id"] = member_id
-
         match = matches.get(segment_index)
+        if match:
+            member_id = match.live.message.from_member_id
+            member_name = match.live.message.from_name
+            if member_id is not None and member_name:
+                update["speaker"] = member_name
+                update["member_id"] = member_id
+
+        if "member_id" not in update:
+            speaker_match = speaker_mapping.get(segment.speaker)
+            if speaker_match:
+                member_id, member_name, _ = speaker_match
+                update["speaker"] = member_name
+                update["member_id"] = member_id
+
         if match and match.score >= MIN_CORRECTION_SCORE:
             live_text = (match.live.message.text or "").strip()
             if live_text:
@@ -426,9 +471,156 @@ def _apply_matches(
                         match.score,
                     )
 
-        corrected.append(segment.model_copy(update=update))
+        sort_key = _segment_sort_key(segment, segment_index)
+        corrected.append((sort_key, segment_index, segment.model_copy(update=update)))
 
-    return corrected
+    if matches:
+        for live in live_entries:
+            if live.index in used_live_indexes:
+                continue
+            if live.is_ambiguous:
+                continue
+
+            live_segment = _build_live_only_segment(live, live_entries)
+            if live_segment is None:
+                continue
+            sort_key = _live_sort_key(
+                live=live,
+                segments=segments,
+                matches=matches,
+            )
+            corrected.append((sort_key, len(segments) + live.index, live_segment))
+            logger.info(
+                "live transcript segment added from unmatched WebSocket message: "
+                "live_index=%s member_id=%s",
+                live.index,
+                live.message.from_member_id,
+            )
+
+    sorted_segments = [
+        item[2] for item in sorted(corrected, key=lambda item: (item[0], item[1]))
+    ]
+    return _renumber_segments(sorted_segments)
+
+
+def _build_live_only_segments(
+    live_entries: list[_LiveEntry],
+) -> list[TranscribeSegment]:
+    segments = []
+    for live in live_entries:
+        if live.is_ambiguous:
+            continue
+        live_segment = _build_live_only_segment(live, live_entries)
+        if live_segment is not None:
+            segments.append(live_segment)
+    return segments
+
+
+def _renumber_segments(
+    segments: list[TranscribeSegment],
+) -> list[TranscribeSegment]:
+    return [
+        segment.model_copy(update={"message_id": index})
+        for index, segment in enumerate(segments, start=1)
+    ]
+
+
+def _segment_sort_key(segment: TranscribeSegment, fallback_index: int) -> float:
+    seconds = _parse_time_to_seconds(segment.start_time)
+    if seconds is not None:
+        return seconds
+    return float(fallback_index)
+
+
+def _live_sort_key(
+    *,
+    live: _LiveEntry,
+    segments: list[TranscribeSegment],
+    matches: dict[int, _SegmentMatch],
+) -> float:
+    if live.seconds is not None:
+        return live.seconds
+
+    anchors = sorted(
+        (
+            (
+                match.live.index,
+                _segment_sort_key(segments[segment_index], segment_index),
+            )
+            for segment_index, match in matches.items()
+            if 0 <= segment_index < len(segments)
+        ),
+        key=lambda item: item[0],
+    )
+    if not anchors:
+        return float(live.index)
+
+    previous_anchor = next(
+        (anchor for anchor in reversed(anchors) if anchor[0] < live.index),
+        None,
+    )
+    next_anchor = next((anchor for anchor in anchors if anchor[0] > live.index), None)
+
+    if previous_anchor and next_anchor:
+        previous_index, previous_sort_key = previous_anchor
+        next_index, next_sort_key = next_anchor
+        progress = (live.index - previous_index) / (next_index - previous_index)
+        return previous_sort_key + ((next_sort_key - previous_sort_key) * progress)
+    if previous_anchor:
+        previous_index, previous_sort_key = previous_anchor
+        return previous_sort_key + ((live.index - previous_index) * 0.001)
+    if next_anchor:
+        next_index, next_sort_key = next_anchor
+        return max(0.0, next_sort_key - ((next_index - live.index) * 0.001))
+    return float(live.index)
+
+
+def _build_live_only_segment(
+    live: _LiveEntry,
+    live_entries: list[_LiveEntry],
+) -> TranscribeSegment | None:
+    text = (live.message.text or "").strip()
+    member_id = live.message.from_member_id
+    member_name = live.message.from_name
+    if not text or member_id is None or not member_name:
+        return None
+
+    start_seconds = live.seconds
+    next_seconds = next(
+        (
+            entry.seconds
+            for entry in live_entries
+            if entry.index > live.index
+            and entry.seconds is not None
+            and start_seconds is not None
+            and entry.seconds > start_seconds
+        ),
+        None,
+    )
+    if start_seconds is None:
+        start_time = "00:00:00"
+        end_time = "00:00:00"
+    else:
+        start_time = _format_seconds(start_seconds)
+        end_time = _format_seconds(next_seconds or start_seconds)
+
+    return TranscribeSegment(
+        message_id=live.index + 1,
+        speaker=member_name,
+        member_id=member_id,
+        start_time=start_time,
+        end_time=end_time,
+        text=text,
+        is_final=True,
+    )
+
+
+def _format_seconds(value: float) -> str:
+    total = max(0, int(value))
+    hours = total // 3600
+    minutes = (total % 3600) // 60
+    seconds = total % 60
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
 
 
 def _parse_time_to_seconds(value: str | None) -> float | None:

--- a/tests/test_application_reason_format.py
+++ b/tests/test_application_reason_format.py
@@ -4,6 +4,7 @@ from app.domains.meeting_analysis.schemas import (
     MeetingAnalysisResult,
 )
 from app.domains.meeting_analysis.services.extraction import (
+    CONCRETE_APPLICATION_RULE,
     NOUN_ENDING_REASON_RULE,
     _normalize_application_reason_outputs,
     _normalize_overall_reason_outputs,
@@ -17,6 +18,13 @@ class TestApplicationReasonFormat:
         assert "명사형 어미" in joined_rule
         assert "절대 출력하지 않는다" in joined_rule
         assert "응답 속도 개선 필요성" in joined_rule
+
+    def test_application_prompt_rule_requires_concrete_action(self):
+        joined_rule = "\n".join(CONCRETE_APPLICATION_RULE)
+
+        assert "실제 실행/반영 단위" in joined_rule
+        assert "두루뭉술한 표현은 절대 사용하지 않는다" in joined_rule
+        assert "WebSocket 발화로그 기준으로 STT 화자 보정 적용" in joined_rule
 
     def test_application_reasons_are_normalized_to_noun_endings(self):
         result = MeetingAnalysisResult(

--- a/tests/test_live_transcript_merge.py
+++ b/tests/test_live_transcript_merge.py
@@ -203,8 +203,12 @@ def test_merge_live_transcript_does_not_use_dominant_fallback_for_mixed_members(
 
     merged = merge_live_transcript(segments, live_messages)
 
-    assert [segment.member_id for segment in merged] == [None, None]
-    assert {segment.speaker for segment in merged} == {"Speaker 0"}
+    assert [segment.member_id for segment in merged] == [9, 10]
+    assert [segment.speaker for segment in merged] == ["김준용", "유상완"]
+    assert [segment.text for segment in merged] == [
+        "완전히 다른 이야기입니다",
+        "또 다른 내용입니다",
+    ]
 
 
 def test_merge_live_transcript_uses_text_and_order_when_timestamp_is_iso_string():
@@ -236,6 +240,197 @@ def test_merge_live_transcript_uses_text_and_order_when_timestamp_is_iso_string(
     assert merged[0].speaker == "김준용"
     assert merged[0].member_id == 1
     assert merged[1].speaker == "김준용"
+
+
+def test_merge_live_transcript_uses_direct_match_member_without_vote_threshold():
+    segments = [
+        _segment(1, "Speaker 0", "00:00:00", "웹소켓 발화 로그로 보정해야 합니다"),
+        _segment(2, "Speaker 1", "00:00:05", "STT 전사와 합쳐서 보여주겠습니다"),
+        _segment(3, "Speaker 0", "00:00:10", "최종 결과를 저장하겠습니다"),
+    ]
+    live_messages = [
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=143,
+            fromMemberId=1,
+            fromName="유상완",
+            timestamp="00:00:00",
+            text="웹소켓 발화 로그로 보정해야 합니다",
+        ),
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=143,
+            fromMemberId=2,
+            fromName="유진",
+            timestamp="00:00:05",
+            text="STT 전사와 합쳐서 보여주겠습니다",
+        ),
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=143,
+            fromMemberId=3,
+            fromName="김준용",
+            timestamp="00:00:10",
+            text="최종 결과를 저장하겠습니다",
+        ),
+    ]
+
+    merged = merge_live_transcript(segments, live_messages)
+
+    assert [segment.member_id for segment in merged] == [1, 2, 3]
+    assert [segment.speaker for segment in merged] == ["유상완", "유진", "김준용"]
+
+
+def test_merge_live_transcript_preserves_unmatched_live_messages_as_segments():
+    segments = [
+        _segment(
+            1,
+            "Speaker 0",
+            "00:00:00",
+            "웹소켓 발화 로그로 화자를 보정하고 STT 전사를 강화하겠습니다",
+        ),
+        _segment(2, "Speaker 1", "00:00:12", "결과를 저장하겠습니다"),
+    ]
+    live_messages = [
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=143,
+            fromMemberId=1,
+            fromName="유상완",
+            timestamp="00:00:00",
+            text="웹소켓 발화 로그로 화자를 보정하겠습니다",
+        ),
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=143,
+            fromMemberId=2,
+            fromName="유진",
+            timestamp="00:00:06",
+            text="STT 전사를 같이 보고 강화하겠습니다",
+        ),
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=143,
+            fromMemberId=3,
+            fromName="김준용",
+            timestamp="00:00:12",
+            text="결과를 저장하겠습니다",
+        ),
+    ]
+
+    merged = merge_live_transcript(segments, live_messages)
+
+    assert [segment.member_id for segment in merged] == [1, 2, 3]
+    assert [segment.speaker for segment in merged] == ["유상완", "유진", "김준용"]
+    assert [segment.text for segment in merged] == [
+        "웹소켓 발화 로그로 화자를 보정하겠습니다",
+        "STT 전사를 같이 보고 강화하겠습니다",
+        "결과를 저장하겠습니다",
+    ]
+
+
+def test_merge_live_transcript_orders_unmatched_iso_live_messages_by_anchor():
+    segments = [
+        _segment(1, "Speaker 0", "00:01:48", "첫 번째 안건을 공유하겠습니다"),
+        _segment(2, "Speaker 1", "00:02:10", "세 번째 안건을 정리하겠습니다"),
+    ]
+    live_messages = [
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=143,
+            fromMemberId=1,
+            fromName="유상완",
+            timestamp="2026-05-04T17:00:00",
+            text="첫 번째 안건을 공유하겠습니다",
+        ),
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=143,
+            fromMemberId=2,
+            fromName="유진",
+            timestamp="2026-05-04T17:00:02",
+            text="두 번째 안건도 추가로 확인하겠습니다",
+        ),
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=143,
+            fromMemberId=3,
+            fromName="김준용",
+            timestamp="2026-05-04T17:00:04",
+            text="세 번째 안건을 정리하겠습니다",
+        ),
+    ]
+
+    merged = merge_live_transcript(segments, live_messages)
+
+    assert [segment.member_id for segment in merged] == [1, 2, 3]
+    assert [segment.text for segment in merged] == [
+        "첫 번째 안건을 공유하겠습니다",
+        "두 번째 안건도 추가로 확인하겠습니다",
+        "세 번째 안건을 정리하겠습니다",
+    ]
+
+
+def test_merge_live_transcript_uses_websocket_only_when_no_stt_matches():
+    segments = [
+        _segment(1, "Speaker 0", "00:00:00", "노이즈가 심해서 내용이 다릅니다"),
+    ]
+    live_messages = [
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=143,
+            fromMemberId=1,
+            fromName="유상완",
+            timestamp="2026-05-04T17:00:00",
+            text="회의 분석 결과를 확인하겠습니다",
+        ),
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=143,
+            fromMemberId=2,
+            fromName="유진",
+            timestamp="2026-05-04T17:00:02",
+            text="전사 결과도 같이 확인하겠습니다",
+        ),
+    ]
+
+    merged = merge_live_transcript(segments, live_messages)
+
+    assert [segment.member_id for segment in merged] == [1, 2]
+    assert [segment.text for segment in merged] == [
+        "회의 분석 결과를 확인하겠습니다",
+        "전사 결과도 같이 확인하겠습니다",
+    ]
+
+
+def test_merge_live_transcript_global_match_prevents_greedy_steal():
+    segments = [
+        _segment(1, "Speaker 0", "00:00:00", "웹소켓 로그 확인"),
+        _segment(2, "Speaker 1", "00:00:06", "전사 결과를 저장하겠습니다"),
+    ]
+    live_messages = [
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=143,
+            fromMemberId=1,
+            fromName="유상완",
+            timestamp="00:00:00",
+            text="웹소켓 로그를 확인하겠습니다",
+        ),
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=143,
+            fromMemberId=2,
+            fromName="유진",
+            timestamp="00:00:06",
+            text="전사 결과를 저장하겠습니다",
+        ),
+    ]
+
+    merged = merge_live_transcript(segments, live_messages)
+
+    assert [segment.member_id for segment in merged] == [1, 2]
+    assert [segment.speaker for segment in merged] == ["유상완", "유진"]
 
 
 class TestLiveMessagesEndpoint:


### PR DESCRIPTION
## ✨ 작업 개요
WebSocket 발화로그를 더 신뢰 가능한 기준으로 활용해 STT 전사 결과의 화자/멤버/텍스트 보강을 강화했습니다.

또한 회의 분석의 적용사항/적용합의 표현이 두루뭉술한 주제가 아니라 실제 실행 단위로 나오도록 프롬프트 규칙을 추가했습니다.

## 📄 작업 내용
- WebSocket 발화로그 기반 전사 보강 로직 개선
  - 직접 매칭된 WebSocket 발화의 `fromMemberId`, `fromName`을 `member_id`, `speaker`에 반영
  - 세그먼트 순서 기반 탐욕 매칭을 전체 후보 점수 기반 매칭으로 변경
  - STT가 발화를 누락하거나 뭉갠 경우, 매칭되지 않은 WebSocket 발화를 별도 전사 세그먼트로 보존
  - STT와 WebSocket이 아예 매칭되지 않을 정도로 STT가 노이즈인 경우 WebSocket-only fallback 적용
  - ISO timestamp 기반 WebSocket fallback 세그먼트 정렬 보정
- 잘못된 매칭 방지
  - 텍스트 유사도 최소 기준을 추가해 시간/순서만으로 전혀 다른 발화를 붙이지 않도록 제한
  - 짧고 모호한 발화는 기존처럼 보수적으로 처리
- 적용사항 추출 프롬프트 구체화
  - `application_title`을 주제명이 아닌 실제 실행/반영 단위로 작성하도록 규칙 추가
  - timeline의 `적용합의` content도 구체적인 실행 문장으로 작성하도록 제한
- 관련 테스트 추가 및 갱신
  - 3명 이상 WebSocket 발화로그 반영 케이스
  - STT 누락 발화 보존 케이스
  - ISO timestamp fallback 정렬 케이스
  - WebSocket-only fallback 케이스
  - 적용사항 구체화 프롬프트 규칙 검증

## 📌 관련 이슈
- close #42

## 🔌 API 변경사항 (해당 시)
- 기존 요청/응답 필드 변경은 없습니다.
- `live_messages`를 함께 전달한 경우 최종 `transcript_segments`의 `speaker`, `member_id`, `text`가 WebSocket 발화로그 기준으로 더 적극 보강될 수 있습니다.

## 💬 기타 사항
- WebSocket 발화로그 신뢰 판단 기준
  - 유효한 `fromMemberId`, `fromName`, `text`가 있어야 합니다.
  - STT 세그먼트와 WebSocket 발화의 텍스트 유사도, 시간, 순서 점수가 기준 이상이어야 직접 매칭됩니다.
  - 직접 매칭된 발화는 WebSocket의 멤버 정보를 우선 사용합니다.
  - STT가 노이즈라 매칭이 0건이면, WebSocket 발화로그 자체를 최종 전사 기준으로 사용하는 fallback을 둡니다.
- 검증: `uv run ruff check app tests services schemas routers utils`, `uv run ruff format --check .`, `uv run pytest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 회의 분석 추출 시 보다 구체적이고 명확한 언어 요구사항 강화
  * 실시간 트랜스크립트 병합 시 화자 식별 및 매칭 로직 개선
  * 매칭되지 않은 메시지 처리 및 순서 정렬 최적화

* **테스트**
  * 추출 규칙 검증 테스트 추가
  * 실시간 트랜스크립트 병합 기능 테스트 확대

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhyLog-App/Whylog-AI/pull/43)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->