### PR TITLE
[feat/#44] 커밋 추천 reason 구체화 및 score_detail 분리

### DIFF
--- a/app/domains/commit/schemas.py
+++ b/app/domains/commit/schemas.py
@@ -142,7 +142,10 @@ class MatchedCommit(BaseModel):
     commit_message: str | None = Field(default=None, description="커밋 메시지")
     repository_id: int | None = Field(default=None, description="Spring 레포지토리 ID")
     confidence: int = Field(description="신뢰도 점수(0~100)")
-    reason: str = Field(description="추천 사유 요약")
+    reason: str = Field(description="추천 사유 요약(사람이 읽기 좋은 문장)")
+    score_detail: str = Field(
+        description="점수 분해 상세(총점·항목별·겹친 키워드/모듈)"
+    )
     score_breakdown: MatchScoreBreakdown = Field(description="점수 구성 상세")
     direction_primary: str | None = Field(default=None, description="대표 변경 방향")
     direction_multi: list[str] = Field(

--- a/app/domains/commit/services/matching.py
+++ b/app/domains/commit/services/matching.py
@@ -14,6 +14,7 @@ from app.domains.commit.schemas import (
 )
 from app.domains.meeting_analysis.services.matching_scoring import (
     ScoringInput,
+    build_connection_reason,
     calculate_match_score,
     extract_direction_labels_from_text,
     extract_module_tokens,
@@ -320,7 +321,12 @@ def _build_match_record(
         commit_message=commit_message,
         repository_id=repository_id,
         confidence=score.total,
-        reason=_build_recommendation_reason(
+        reason=build_connection_reason(
+            score,
+            keyword_overlap=application.keywords & commit_keywords,
+            module_overlap=application.modules & commit_modules,
+        ),
+        score_detail=_build_recommendation_reason(
             score=score,
             application_keywords=application.keywords,
             commit_keywords=commit_keywords,

--- a/app/domains/meeting_analysis/services/matching_scoring.py
+++ b/app/domains/meeting_analysis/services/matching_scoring.py
@@ -380,7 +380,21 @@ def resolve_match_status(total_score: int) -> MatchStatus:
     return "UNAPPLIED"
 
 
-def build_connection_reason(score: ScoreBreakdown) -> str:
+def _format_overlap(tokens: set[str], *, limit: int = 3) -> str:
+    sorted_tokens = sorted(tokens)
+    shown = sorted_tokens[:limit]
+    suffix = (
+        "" if len(sorted_tokens) <= limit else f" 외 {len(sorted_tokens) - limit}개"
+    )
+    return ", ".join(shown) + suffix
+
+
+def build_connection_reason(
+    score: ScoreBreakdown,
+    *,
+    keyword_overlap: set[str] | None = None,
+    module_overlap: set[str] | None = None,
+) -> str:
     if score.total < 50:
         return "신뢰도 임계치 미달로 자동 연결하지 않았습니다."
     if score.is_opposite_direction:
@@ -389,17 +403,28 @@ def build_connection_reason(score: ScoreBreakdown) -> str:
         return "키워드는 유사하지만 변경 목적이 달라 자동 연결을 제한했습니다."
 
     reason_parts: list[str] = []
+
     if score.semantic >= 30:
         reason_parts.append("의미 유사성이 높습니다")
     elif score.semantic > 0:
         reason_parts.append("의미 유사성이 일부 확인됩니다")
 
-    if score.keyword >= 25:
+    if score.keyword >= 25 and keyword_overlap:
+        reason_parts.append(
+            f"{_format_overlap(keyword_overlap)} 키워드가 다수 일치합니다"
+        )
+    elif score.keyword >= 15 and keyword_overlap:
+        reason_parts.append(f"{_format_overlap(keyword_overlap)} 키워드가 일치합니다")
+    elif score.keyword >= 25:
         reason_parts.append("핵심 기술 키워드가 다수 일치합니다")
     elif score.keyword >= 15:
         reason_parts.append("핵심 기술 키워드가 일부 일치합니다")
 
-    if score.context >= 20:
+    if score.context >= 20 and module_overlap:
+        reason_parts.append(f"{_format_overlap(module_overlap)} 모듈이 직접 일치합니다")
+    elif score.context >= 10 and module_overlap:
+        reason_parts.append(f"{_format_overlap(module_overlap)} 모듈이 간접 일치합니다")
+    elif score.context >= 20:
         reason_parts.append("파일/모듈 맥락이 직접 일치합니다")
     elif score.context >= 10:
         reason_parts.append("파일/모듈 맥락이 간접 일치합니다")

--- a/tests/test_application_commit_matching.py
+++ b/tests/test_application_commit_matching.py
@@ -172,8 +172,9 @@ class TestApplicationCommitMatchingService:
             "feat: introduce redis queue"
         )
         assert item.recommended_commits[0].confidence >= 70
-        assert "총" in item.recommended_commits[0].reason
-        assert "겹친 키워드" in item.recommended_commits[0].reason
+        assert item.recommended_commits[0].reason.endswith(".")
+        assert "총" in item.recommended_commits[0].score_detail
+        assert "겹친 키워드" in item.recommended_commits[0].score_detail
         assert item.recommended_commits[1].commit_hash == "h2"
         assert item.recommended_commits[0].confidence >= (
             item.recommended_commits[1].confidence


### PR DESCRIPTION
## ✨ 작업 개요

커밋 추천 응답의 `reason` 필드를 점수 구간 텍스트에서 실제 겹친 키워드·모듈명이 담긴 구체적인 사유 문장으로 교체하고, 기존 점수 분해 텍스트는 `score_detail` 필드로 분리합니다.

## 📄 작업 내용

- `reason`: `build_connection_reason` 기반 사람이 읽기 좋은 사유 문장으로 교체 (겹친 키워드·모듈명 포함)
- `score_detail` 필드 신설: 기존 점수 분해 텍스트 유지 (총점·항목별·겹친 토큰)
- `build_connection_reason`에 `keyword_overlap`, `module_overlap` 파라미터 추가

**변경 전**
```
reason: "총 84점: 의미 44/50, 키워드 30/30, 맥락 20/20. 겹친 키워드: swagger, error, api."
```

**변경 후**
```
reason: "의미 유사성이 높습니다, api, error, swagger 키워드가 다수 일치합니다, api, swagger 모듈이 직접 일치합니다."
score_detail: "총 84점: 의미 44/50, 키워드 30/30, 맥락 20/20. 겹친 키워드: api, error, swagger. 겹친 모듈: api, swagger."
```

## 📌 관련 이슈

- close #44

## 🔌 API 변경사항 (해당 시)

`POST /api/commit/match` 응답 `MatchedCommit` 필드 변경

| 필드 | 변경 내용 |
|---|---|
| `reason` | 점수 분해 텍스트 → 구체적 사유 문장 (Breaking Change) |
| `score_detail` | 신규 추가 (기존 reason 내용) |

## 💬 기타 사항

Spring 연동 시 `reason` 필드 파싱 로직이 있다면 수정 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 커밋 추천 결과에 상세한 점수 분석 정보가 추가되었습니다. 전체 합계, 항목별 구성, 겹친 키워드 및 모듈에 대한 상세 정보를 확인할 수 있습니다.

## 개선 사항
* 연결 이유 표시 형식이 개선되어 더욱 명확하고 직관적인 정보를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->