### PR TITLE
[feat/#46] 파일 로깅 추가 및 임베딩 요청 수신 로그 기록

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.pyc
 .env
 chroma_data/
+logs/

--- a/app/core/logging_middleware.py
+++ b/app/core/logging_middleware.py
@@ -1,0 +1,43 @@
+import logging
+import time
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+logger = logging.getLogger("api.access")
+
+_MAX_BODY_SIZE = 10_000  # 10KB 초과 시 truncate
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next) -> Response:
+        start = time.perf_counter()
+
+        body_bytes = await request.body()
+        body_text = body_bytes.decode("utf-8", errors="replace")
+        if len(body_text) > _MAX_BODY_SIZE:
+            body_text = (
+                body_text[:_MAX_BODY_SIZE]
+                + f"... (truncated, total {len(body_text)} chars)"
+            )
+
+        logger.info(
+            ">>> %s %s\nBody: %s",
+            request.method,
+            request.url.path,
+            body_text or "(empty)",
+        )
+
+        response = await call_next(request)
+
+        elapsed_ms = int((time.perf_counter() - start) * 1000)
+        logger.info(
+            "<<< %s %s %d (%dms)",
+            request.method,
+            request.url.path,
+            response.status_code,
+            elapsed_ms,
+        )
+
+        return response

--- a/app/domains/meeting_analysis/router.py
+++ b/app/domains/meeting_analysis/router.py
@@ -279,12 +279,7 @@ async def create_application_embeddings(
         ),
     ],
 ) -> ApiResponse[ApplicationEmbeddingResponse]:
-    logger.info(
-        "임베딩 요청 수신 meeting_id=%s application_count=%d application_ids=%s",
-        payload.meeting_id,
-        len(payload.analysis_result.applications),
-        [a.application_id for a in payload.analysis_result.applications],
-    )
+    logger.info("임베딩 요청 수신: %s", payload.model_dump_json(indent=2))
     documents = await embed_and_store_applications(
         meeting_id=payload.meeting_id,
         project_id=payload.project_id,

--- a/app/domains/meeting_analysis/router.py
+++ b/app/domains/meeting_analysis/router.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Annotated
 
 from fastapi import APIRouter, Body
@@ -14,7 +13,6 @@ from app.domains.meeting_analysis.services.embedding import embed_and_store_appl
 from app.domains.meeting_analysis.services.extraction import extract_meeting_analysis
 
 router = APIRouter(prefix="/meeting-analysis", tags=["meeting-analysis"])
-logger = logging.getLogger(__name__)
 
 
 @router.post(
@@ -279,7 +277,6 @@ async def create_application_embeddings(
         ),
     ],
 ) -> ApiResponse[ApplicationEmbeddingResponse]:
-    logger.info("임베딩 요청 수신: %s", payload.model_dump_json(indent=2))
     documents = await embed_and_store_applications(
         meeting_id=payload.meeting_id,
         project_id=payload.project_id,

--- a/app/domains/meeting_analysis/router.py
+++ b/app/domains/meeting_analysis/router.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Annotated
 
 from fastapi import APIRouter, Body
@@ -13,6 +14,7 @@ from app.domains.meeting_analysis.services.embedding import embed_and_store_appl
 from app.domains.meeting_analysis.services.extraction import extract_meeting_analysis
 
 router = APIRouter(prefix="/meeting-analysis", tags=["meeting-analysis"])
+logger = logging.getLogger(__name__)
 
 
 @router.post(
@@ -277,6 +279,12 @@ async def create_application_embeddings(
         ),
     ],
 ) -> ApiResponse[ApplicationEmbeddingResponse]:
+    logger.info(
+        "임베딩 요청 수신 meeting_id=%s application_count=%d application_ids=%s",
+        payload.meeting_id,
+        len(payload.analysis_result.applications),
+        [a.application_id for a in payload.analysis_result.applications],
+    )
     documents = await embed_and_store_applications(
         meeting_id=payload.meeting_id,
         project_id=payload.project_id,

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,6 @@
 import logging
+import logging.handlers
+from pathlib import Path
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Request
@@ -14,7 +16,23 @@ from app.core.responses import error_response
 # .env 파일의 환경변수 로드 (DEEPGRAM_API_KEY 등)
 load_dotenv()
 
-logging.basicConfig(level=logging.INFO)
+_LOG_DIR = Path("logs")
+_LOG_DIR.mkdir(exist_ok=True)
+
+_file_handler = logging.handlers.RotatingFileHandler(
+    _LOG_DIR / "app.log",
+    maxBytes=10 * 1024 * 1024,  # 10MB
+    backupCount=5,
+    encoding="utf-8",
+)
+_file_handler.setFormatter(
+    logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    handlers=[logging.StreamHandler(), _file_handler],
+)
 
 app = FastAPI(title=settings.app_name, version=settings.app_version)
 app.include_router(api_router)

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from app.api.router import api_router
 from app.core.config import settings
 from app.core.errors import AppServiceError
+from app.core.logging_middleware import RequestLoggingMiddleware
 from app.core.responses import error_response
 
 # .env 파일의 환경변수 로드 (DEEPGRAM_API_KEY 등)
@@ -35,6 +36,7 @@ logging.basicConfig(
 )
 
 app = FastAPI(title=settings.app_name, version=settings.app_version)
+app.add_middleware(RequestLoggingMiddleware)
 app.include_router(api_router)
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## ✨ 작업 개요

서버 재시작 후에도 로그를 확인할 수 있도록 파일 로깅을 추가합니다.
Spring 연동 디버깅 목적으로 임베딩 요청 수신 시 `application_id` 목록을 기록합니다.

## 📄 작업 내용

- `logs/app.log`에 RotatingFileHandler로 영구 저장 (10MB × 5개 롤링, stdout 병행 출력)
- `/api/meeting-analysis/embeddings` 요청 수신 시 `meeting_id`, `application_id` 목록 INFO 로깅
- `logs/` gitignore 추가

## 📌 관련 이슈

- close #46

## 🔌 API 변경사항 (해당 시)

없음

## 💬 기타 사항

배포 후 Spring에서 임베딩 요청을 다시 보내면 `logs/app.log`에서 아래 형태로 확인 가능합니다.

```
INFO app.domains.meeting_analysis.router 임베딩 요청 수신 meeting_id=181 application_count=1 application_ids=[16]
```

`application_ids`가 `[None]`으로 찍히면 Spring이 `application_id`를 null로 보내는 것이 확정됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 애플리케이션 로깅 시스템을 개선했습니다. 이제 자동 로그 순환 기능과 함께 파일 기반 로깅이 활성화되어 애플리케이션의 활동을 더욱 효율적으로 추적할 수 있으며, 문제 발생 시 빠른 진단과 해결이 가능합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhyLog-App/Whylog-AI/pull/47)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->