### PR TITLE
[feat/#48] Gemini LLM 모델 환경변수로 관리

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -14,6 +14,11 @@ class AppSettings(BaseModel):
 
     # Gemini
     gemini_api_key: str = Field(default_factory=lambda: os.getenv("GEMINI_API_KEY", ""))
+    gemini_llm_model: str = Field(
+        default_factory=lambda: os.getenv(
+            "GEMINI_LLM_MODEL", "gemini-3.1-flash-lite-preview"
+        )
+    )
 
     # ChromaDB
     chroma_persist_dir: str = Field(

--- a/app/domains/commit/services/summarize.py
+++ b/app/domains/commit/services/summarize.py
@@ -11,7 +11,6 @@ from app.core.config import settings
 from app.core.errors import AppServiceError
 from app.domains.commit.schemas import ChangedFile
 
-GEMINI_MODEL = "gemini-3.1-flash-lite-preview"
 RETRY_STATUS_CODES = {500, 502, 503, 504}
 RETRY_BACKOFFS = (1.0, 2.0)  # 1차 실패 후 1초, 2차 실패 후 2초 대기
 logger = logging.getLogger(__name__)
@@ -125,7 +124,7 @@ async def _call_gemini(
         try:
             response = await asyncio.wait_for(
                 client.aio.models.generate_content(
-                    model=GEMINI_MODEL,
+                    model=settings.gemini_llm_model,
                     contents=f"{prompt}\n\n{user_message}",
                     config=types.GenerateContentConfig(temperature=0.3),
                 ),

--- a/app/domains/meeting_analysis/services/extraction.py
+++ b/app/domains/meeting_analysis/services/extraction.py
@@ -7,6 +7,7 @@ from google import genai
 from google.genai import types
 from pydantic import BaseModel, Field
 
+from app.core.config import settings
 from app.core.errors import AppServiceError
 from app.domains.meeting_analysis.schemas import (
     Application,
@@ -15,7 +16,6 @@ from app.domains.meeting_analysis.schemas import (
 )
 from app.domains.transcribe.schemas import TranscribeSegment
 
-GEMINI_MODEL = "gemini-3.1-flash-lite-preview"
 logger = logging.getLogger(__name__)
 AMBIGUOUS_SHORT_UTTERANCES = {
     "네",
@@ -294,7 +294,7 @@ async def _request_gemini_json(
     client = genai.Client(api_key=api_key)
     try:
         response = await client.aio.models.generate_content(
-            model=GEMINI_MODEL,
+            model=settings.gemini_llm_model,
             contents=prompt,
             config=types.GenerateContentConfig(
                 response_mime_type="application/json",

--- a/app/domains/transcribe/services/transcript_correction.py
+++ b/app/domains/transcribe/services/transcript_correction.py
@@ -5,11 +5,10 @@ import os
 from google import genai
 from google.genai import types
 
+from app.core.config import settings
 from app.core.errors import AppServiceError
 from app.domains.transcribe.schemas import TranscribeSegment
 
-# 사용할 Gemini 모델
-GEMINI_MODEL = "gemini-3.1-flash-lite-preview"
 logger = logging.getLogger(__name__)
 
 # LLM에게 전달할 후처리 지침
@@ -101,7 +100,7 @@ async def correct_transcript(
     try:
         # JSON 모드 강제 + temperature 낮춰 일관성 확보
         response = await client.aio.models.generate_content(
-            model=GEMINI_MODEL,
+            model=settings.gemini_llm_model,
             contents=f"{SYSTEM_PROMPT}\n\n{user_message}",
             config=types.GenerateContentConfig(
                 response_mime_type="application/json",


### PR DESCRIPTION
## ✨ 작업 개요

`gemini-3.1-flash-lite-preview` 모델명이 3개 파일에 하드코딩되어 있어 모델 교체가 어려웠습니다. `GEMINI_LLM_MODEL` 환경변수로 통합 관리합니다.

## 📄 작업 내용

- `config.py`에 `gemini_llm_model` 필드 추가 (`GEMINI_LLM_MODEL` env, 기본값 `gemini-3.1-flash-lite-preview`)
- `commit/services/summarize.py` 하드코딩 제거 → `settings.gemini_llm_model`
- `meeting_analysis/services/extraction.py` 하드코딩 제거 → `settings.gemini_llm_model`
- `transcribe/services/transcript_correction.py` 하드코딩 제거 → `settings.gemini_llm_model`

## 📌 관련 이슈

- close #48

## 🔌 API 변경사항 (해당 시)

없음

## 💬 기타 사항

머지 후 EC2 `.env`에 항목 추가 및 컨테이너 재시작 필요합니다.

```
GEMINI_LLM_MODEL=gemini-3.1-flash-lite-preview
```