### PR TITLE
[fix/#50] Gemini 호출 재시도 처리 추가

### DIFF
--- a/app/core/gemini.py
+++ b/app/core/gemini.py
@@ -1,0 +1,68 @@
+import asyncio
+import logging
+from collections.abc import Sequence
+from typing import Any
+
+from google import genai
+from google.genai import errors as genai_errors
+from google.genai import types
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+RETRY_STATUS_CODES = {429, 500, 502, 503, 504}
+DEFAULT_RETRY_BACKOFFS = (1.0, 2.0, 4.0)
+
+
+async def generate_content_with_retry(
+    client: genai.Client,
+    *,
+    contents: Any,
+    config: types.GenerateContentConfig,
+    timeout: float,
+    operation_name: str,
+    backoffs: Sequence[float] = DEFAULT_RETRY_BACKOFFS,
+) -> Any:
+    """Gemini generate_content 호출에 timeout/retry 정책을 공통 적용한다."""
+    last_error: Exception | None = None
+
+    for attempt in range(len(backoffs) + 1):
+        try:
+            return await asyncio.wait_for(
+                client.aio.models.generate_content(
+                    model=settings.gemini_llm_model,
+                    contents=contents,
+                    config=config,
+                ),
+                timeout=timeout,
+            )
+        except TimeoutError as e:
+            last_error = e
+            if attempt >= len(backoffs):
+                raise
+            backoff = backoffs[attempt]
+            logger.warning(
+                "%s 타임아웃, %.1f초 후 재시도 (%d/%d)",
+                operation_name,
+                backoff,
+                attempt + 1,
+                len(backoffs),
+            )
+            await asyncio.sleep(backoff)
+        except genai_errors.APIError as e:
+            last_error = e
+            if e.code not in RETRY_STATUS_CODES or attempt >= len(backoffs):
+                raise
+            backoff = backoffs[attempt]
+            logger.warning(
+                "%s %s 응답, %.1f초 후 재시도 (%d/%d)",
+                operation_name,
+                e.code,
+                backoff,
+                attempt + 1,
+                len(backoffs),
+            )
+            await asyncio.sleep(backoff)
+
+    raise last_error  # type: ignore[misc]

--- a/app/domains/commit/services/summarize.py
+++ b/app/domains/commit/services/summarize.py
@@ -9,9 +9,9 @@ from google.genai import types
 from app.core.chroma import get_commit_collection
 from app.core.config import settings
 from app.core.errors import AppServiceError
+from app.core.gemini import RETRY_STATUS_CODES, generate_content_with_retry
 from app.domains.commit.schemas import ChangedFile
 
-RETRY_STATUS_CODES = {500, 502, 503, 504}
 RETRY_BACKOFFS = (1.0, 2.0)  # 1차 실패 후 1초, 2차 실패 후 2초 대기
 logger = logging.getLogger(__name__)
 
@@ -118,35 +118,15 @@ def _build_commit_input(message: str, changed_file_list: list[ChangedFile]) -> s
 async def _call_gemini(
     client: genai.Client, prompt: str, user_message: str, timeout: float
 ) -> str:
-    last_error: Exception | None = None
-    # 최초 1회 + RETRY_BACKOFFS 만큼 재시도
-    for attempt in range(len(RETRY_BACKOFFS) + 1):
-        try:
-            response = await asyncio.wait_for(
-                client.aio.models.generate_content(
-                    model=settings.gemini_llm_model,
-                    contents=f"{prompt}\n\n{user_message}",
-                    config=types.GenerateContentConfig(temperature=0.3),
-                ),
-                timeout=timeout,
-            )
-            return response.text.strip()
-        except genai_errors.APIError as e:
-            # 일시적 5xx만 재시도, 4xx(인증/쿼터 등)는 즉시 실패
-            if e.code not in RETRY_STATUS_CODES or attempt >= len(RETRY_BACKOFFS):
-                raise
-            backoff = RETRY_BACKOFFS[attempt]
-            logger.warning(
-                "Gemini %s 응답, %.1f초 후 재시도 (%d/%d)",
-                e.code,
-                backoff,
-                attempt + 1,
-                len(RETRY_BACKOFFS),
-            )
-            last_error = e
-            await asyncio.sleep(backoff)
-    # 도달 불가 (위에서 raise 또는 return)
-    raise last_error  # type: ignore[misc]
+    response = await generate_content_with_retry(
+        client,
+        contents=f"{prompt}\n\n{user_message}",
+        config=types.GenerateContentConfig(temperature=0.3),
+        timeout=timeout,
+        operation_name="Gemini 커밋 분석",
+        backoffs=RETRY_BACKOFFS,
+    )
+    return response.text.strip()
 
 
 async def _generate_embedding(text: str, timeout: float = 30.0) -> list[float]:

--- a/app/domains/meeting_analysis/services/extraction.py
+++ b/app/domains/meeting_analysis/services/extraction.py
@@ -7,8 +7,8 @@ from google import genai
 from google.genai import types
 from pydantic import BaseModel, Field
 
-from app.core.config import settings
 from app.core.errors import AppServiceError
+from app.core.gemini import generate_content_with_retry
 from app.domains.meeting_analysis.schemas import (
     Application,
     MeetingAnalysis,
@@ -293,13 +293,15 @@ async def _request_gemini_json(
 
     client = genai.Client(api_key=api_key)
     try:
-        response = await client.aio.models.generate_content(
-            model=settings.gemini_llm_model,
+        response = await generate_content_with_retry(
+            client,
             contents=prompt,
             config=types.GenerateContentConfig(
                 response_mime_type="application/json",
                 temperature=0.1,
             ),
+            timeout=90.0,
+            operation_name=failure_context,
         )
     except Exception as e:
         raise AppServiceError(

--- a/app/domains/transcribe/services/transcript_correction.py
+++ b/app/domains/transcribe/services/transcript_correction.py
@@ -5,8 +5,8 @@ import os
 from google import genai
 from google.genai import types
 
-from app.core.config import settings
 from app.core.errors import AppServiceError
+from app.core.gemini import generate_content_with_retry
 from app.domains.transcribe.schemas import TranscribeSegment
 
 logger = logging.getLogger(__name__)
@@ -99,13 +99,15 @@ async def correct_transcript(
 
     try:
         # JSON 모드 강제 + temperature 낮춰 일관성 확보
-        response = await client.aio.models.generate_content(
-            model=settings.gemini_llm_model,
+        response = await generate_content_with_retry(
+            client,
             contents=f"{SYSTEM_PROMPT}\n\n{user_message}",
             config=types.GenerateContentConfig(
                 response_mime_type="application/json",
                 temperature=0.1,
             ),
+            timeout=90.0,
+            operation_name="Gemini 전사 후처리",
         )
         parsed = json.loads(response.text)
         return _validate_raw_segments(parsed)

--- a/tests/test_gemini_retry.py
+++ b/tests/test_gemini_retry.py
@@ -1,0 +1,37 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from google.genai import types
+
+from app.core.gemini import generate_content_with_retry
+
+
+class _SlowThenSuccessModels:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def generate_content(self, **kwargs):
+        _ = kwargs
+        self.calls += 1
+        if self.calls == 1:
+            await asyncio.sleep(0.05)
+        return SimpleNamespace(text="ok")
+
+
+@pytest.mark.asyncio
+async def test_generate_content_with_retry_retries_timeout() -> None:
+    models = _SlowThenSuccessModels()
+    client = SimpleNamespace(aio=SimpleNamespace(models=models))
+
+    response = await generate_content_with_retry(
+        client,
+        contents="prompt",
+        config=types.GenerateContentConfig(temperature=0.1),
+        timeout=0.01,
+        operation_name="Gemini 테스트",
+        backoffs=(0.0,),
+    )
+
+    assert response.text == "ok"
+    assert models.calls == 2


### PR DESCRIPTION
## ✨ 작업 개요

Gemini API 호출 중 timeout, 429 quota, 5xx 일시 오류가 발생했을 때 즉시 실패하지 않고 짧게 재시도하도록 보강했습니다.

## 📄 작업 내용

- Gemini `generate_content` 공통 retry helper 추가
- `429`, `500`, `502`, `503`, `504` 응답 재시도 처리
- timeout 발생 시 backoff 후 재시도 처리
- 커밋 요약/임베딩 텍스트 생성, 회의 요약/적용사항 추출, 전사 후처리에 공통 retry 적용
- timeout 재시도 동작 테스트 추가

## 📌 관련 이슈

- close #50

## 🔌 API 변경사항 (해당 시)

없음

## 💬 기타 사항

- 재시도 backoff는 `1s → 2s → 4s`입니다.
- quota가 완전히 소진된 경우에는 재시도 후에도 실패할 수 있습니다.
- 로컬 검증: `ruff check`, `ruff format --check`, `pytest` 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * API 호출을 위한 재시도 및 타임아웃 메커니즘 추가

* **리팩토링**
  * 여러 서비스를 공유된 재시도 헬퍼로 통합하여 일관성 향상

* **테스트**
  * 재시도 메커니즘에 대한 테스트 커버리지 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhyLog-App/Whylog-AI/pull/51)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->