### PR TITLE
[improve/#52] WebSocket 전사 병합 기준 보강

### DIFF
--- a/app/domains/transcribe/services/live_transcript_merge.py
+++ b/app/domains/transcribe/services/live_transcript_merge.py
@@ -37,6 +37,10 @@ MIN_SPEAKER_AVG_SCORE = 0.6
 MIN_DOMINANT_MEMBER_SHARE = 0.75
 MIN_TEXT_SIMILARITY_FOR_MATCH = 0.6
 TIME_WINDOW_SECONDS = 12.0
+PARSEABLE_TIME_WEIGHTS = (0.45, 0.45, 0.10)
+UNRELIABLE_TIME_WEIGHTS = (0.15, 0.55, 0.30)
+MIN_TEXT_SIMILARITY_FOR_CORRECTION = 0.65
+MIN_LIVE_TEXT_LENGTH_RATIO_FOR_CORRECTION = 0.55
 _live_messages_adapter = TypeAdapter(list[LiveTranscriptMessage])
 
 
@@ -220,8 +224,16 @@ def _score_match(
     text_similarity = SequenceMatcher(None, segment_text, live.normalized_text).ratio()
     time_score = _time_score(segment_seconds, live.seconds)
     order_score = _order_score(segment_index, live.index)
+    time_weight, text_weight, order_weight = _score_weights(
+        segment_seconds,
+        live.seconds,
+    )
 
-    score = (time_score * 0.45) + (text_similarity * 0.45) + (order_score * 0.10)
+    score = (
+        (time_score * time_weight)
+        + (text_similarity * text_weight)
+        + (order_score * order_weight)
+    )
     if live.is_ambiguous:
         score *= 0.45
     return score, text_similarity
@@ -462,7 +474,7 @@ def _apply_matches(
 
         if match and match.score >= MIN_CORRECTION_SCORE:
             live_text = (match.live.message.text or "").strip()
-            if live_text:
+            if live_text and _should_use_live_text(segment.text, live_text, match):
                 update["text"] = live_text
                 if live_text != segment.text:
                     logger.info(
@@ -661,6 +673,15 @@ def _time_score(segment_seconds: float | None, live_seconds: float | None) -> fl
     return max(0.0, 1.0 - (diff / TIME_WINDOW_SECONDS))
 
 
+def _score_weights(
+    segment_seconds: float | None,
+    live_seconds: float | None,
+) -> tuple[float, float, float]:
+    if segment_seconds is None or live_seconds is None:
+        return UNRELIABLE_TIME_WEIGHTS
+    return PARSEABLE_TIME_WEIGHTS
+
+
 def _order_score(segment_index: int, live_index: int) -> float:
     diff = abs(segment_index - live_index)
     if diff >= 6:
@@ -672,6 +693,26 @@ def _normalize_text(value: str) -> str:
     cleaned = re.sub(rf"[{re.escape(punctuation)}]", " ", value.lower())
     cleaned = re.sub(r"[^\w가-힣\s]", " ", cleaned)
     return " ".join(cleaned.split())
+
+
+def _should_use_live_text(
+    segment_text: str,
+    live_text: str,
+    match: _SegmentMatch,
+) -> bool:
+    normalized_segment = _normalize_text(segment_text)
+    normalized_live = _normalize_text(live_text)
+    segment_length = len(normalized_segment.replace(" ", ""))
+    live_length = len(normalized_live.replace(" ", ""))
+    if not normalized_live or live_length == 0:
+        return False
+    if segment_length == 0:
+        return True
+
+    length_ratio = live_length / segment_length
+    if length_ratio < MIN_LIVE_TEXT_LENGTH_RATIO_FOR_CORRECTION:
+        return False
+    return match.text_similarity >= MIN_TEXT_SIMILARITY_FOR_CORRECTION
 
 
 def _is_ambiguous_text(value: str) -> bool:

--- a/tests/test_live_transcript_merge.py
+++ b/tests/test_live_transcript_merge.py
@@ -281,6 +281,39 @@ def test_merge_live_transcript_uses_direct_match_member_without_vote_threshold()
     assert [segment.speaker for segment in merged] == ["유상완", "유진", "김준용"]
 
 
+def test_merge_live_transcript_preserves_long_stt_text_when_live_text_is_partial():
+    segments = [
+        _segment(
+            1,
+            "Speaker 0",
+            "00:00:00",
+            (
+                "웹소켓 발화 로그로 화자를 보정하고 전사 결과를 함께 저장하고 "
+                "적용사항 추출 품질을 높이겠습니다"
+            ),
+        ),
+    ]
+    live_messages = [
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=143,
+            fromMemberId=1,
+            fromName="유상완",
+            timestamp="00:00:00",
+            text="웹소켓 발화 로그로 화자를 보정하고 전사 결과를 함께",
+        ),
+    ]
+
+    merged = merge_live_transcript(segments, live_messages)
+
+    assert merged[0].member_id == 1
+    assert merged[0].speaker == "유상완"
+    assert merged[0].text == (
+        "웹소켓 발화 로그로 화자를 보정하고 전사 결과를 함께 저장하고 "
+        "적용사항 추출 품질을 높이겠습니다"
+    )
+
+
 def test_merge_live_transcript_preserves_unmatched_live_messages_as_segments():
     segments = [
         _segment(


### PR DESCRIPTION
## ✨ 작업 개요
WebSocket 실시간 발화 로그와 STT 전사 결과를 병합할 때, timestamp 신뢰도와 text 길이를 고려해 더 안정적으로 최종 전사를 보강하도록 개선했습니다.

## 📄 작업 내용
- WebSocket/STT 매칭 점수 가중치를 timestamp 신뢰도에 따라 동적으로 조정했습니다.
  - 양쪽 시간이 모두 상대시간으로 해석 가능하면 기존 비중 유지
  - 한쪽이라도 시간 비교가 불안정하면 text/order 비중을 높임
- WebSocket 발화가 부분 문장일 때 긴 STT 전사 텍스트를 덮어쓰지 않도록 보정 기준을 추가했습니다.
- 관련 회귀 테스트를 추가했습니다.

## 📌 관련 이슈
- close #52

## 🔌 API 변경사항 (해당 시)
- 없음
- 기존 `/api/transcribe/*` 응답 구조를 유지합니다.

## ✅ 테스트
- `uv run pytest tests/test_live_transcript_merge.py`
- `uv run ruff format --check app/domains/transcribe/services/live_transcript_merge.py tests/test_live_transcript_merge.py`
- `uv run ruff check app/domains/transcribe/services/live_transcript_merge.py tests/test_live_transcript_merge.py`
- `uv run pytest`

## 💬 기타 사항
- WebSocket 로그가 짧거나 일부만 기록된 경우에는 `member_id`/`speaker`만 보정하고 STT text는 유지합니다.
- 실제 member_id 보정 품질 검증은 Spring에서 실제 WebSocket 발화 로그를 함께 전달한 요청으로 추가 확인하면 됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 라이브 트랜스크립트 병합 시 더 정확한 텍스트 매칭 및 보정 로직 적용
  * 짧은 부분 텍스트가 완전한 텍스트를 덮어쓰는 문제 개선

* **테스트**
  * 라이브 메시지 텍스트가 부분적일 때 전체 STT 텍스트 보존 동작 검증

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhyLog-App/Whylog-AI/pull/55)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->