### PR TITLE
[improve/#21] 적용사항 임베딩에 타임라인 맥락 반영

### DIFF
--- a/app/domains/meeting_analysis/services/embedding.py
+++ b/app/domains/meeting_analysis/services/embedding.py
@@ -7,6 +7,7 @@ from app.core.chroma import get_application_collection
 from app.core.config import settings
 from app.core.errors import AppServiceError
 from app.domains.meeting_analysis.schemas import (
+    Application,
     EmbeddedDocument,
     MeetingAnalysisResult,
 )
@@ -14,6 +15,9 @@ from app.domains.meeting_analysis.schemas import (
 logger = logging.getLogger(__name__)
 _meeting_locks: dict[str, asyncio.Lock] = {}
 _meeting_locks_guard = asyncio.Lock()
+TIMELINE_CONTEXT_MAX_LENGTH = 400
+TIMELINE_AGREEMENT_STEP = "적용합의"
+TIMELINE_DISCUSSION_STEP = "대안논의"
 
 
 async def _get_meeting_lock(meeting_id: str) -> asyncio.Lock:
@@ -55,6 +59,54 @@ def _build_reason_text(application_reasons: list[str]) -> tuple[str, int]:
     return " | ".join(normalized_reasons), total_count
 
 
+def _append_with_budget(
+    values: list[str],
+    item: str,
+    used_length: int,
+    max_length: int,
+) -> int:
+    if used_length >= max_length:
+        return used_length
+    remaining = max_length - used_length
+    trimmed = item[:remaining]
+    if not trimmed:
+        return used_length
+    values.append(trimmed)
+    return used_length + len(trimmed)
+
+
+def _build_timeline_context(application: Application) -> tuple[str, str]:
+    """적용사항 timeline에서 임베딩에 쓸 결론/논의 맥락을 추출한다."""
+    agreements: list[str] = []
+    discussions: list[str] = []
+    seen: set[str] = set()
+    used_length = 0
+
+    for target_step, target_values in (
+        (TIMELINE_AGREEMENT_STEP, agreements),
+        (TIMELINE_DISCUSSION_STEP, discussions),
+    ):
+        for item in application.timeline:
+            if item.step != target_step:
+                continue
+            content = _normalize_text(item.content)
+            if not content or content in seen:
+                continue
+            seen.add(content)
+            used_length = _append_with_budget(
+                target_values,
+                content,
+                used_length,
+                TIMELINE_CONTEXT_MAX_LENGTH,
+            )
+            if used_length >= TIMELINE_CONTEXT_MAX_LENGTH:
+                break
+        if used_length >= TIMELINE_CONTEXT_MAX_LENGTH:
+            break
+
+    return " | ".join(agreements), " | ".join(discussions)
+
+
 def build_embedding_documents(
     meeting_id: str,
     analysis_result: MeetingAnalysisResult,
@@ -62,7 +114,8 @@ def build_embedding_documents(
     """회의 분석 결과에서 application 단위 임베딩 문서를 생성한다.
 
     문서 ID: {meeting_id}_application{i}
-    텍스트: "title: {title} | text: 적용사항: {title} | 근거: {근거들}"
+    텍스트: "title: {title} | text: 적용사항: {title} | 근거: {근거들}
+    | 결론: {적용합의 content} | 논의: {대안논의 content}"
     """
     documents: list[EmbeddedDocument] = []
     total_reasons = 0
@@ -71,11 +124,16 @@ def build_embedding_documents(
     for application_idx, application in enumerate(analysis_result.applications):
         title = _normalize_text(application.application_title)
         reason_text, reason_total = _build_reason_text(application.application_reasons)
+        agreement_text, discussion_text = _build_timeline_context(application)
         total_reasons += reason_total
         doc_id = f"{meeting_id}_application{application_idx}"
         text = f"title: {title or 'none'} | text: 적용사항: {title or 'none'}"
         if reason_text:
             text += f" | 근거: {reason_text}"
+        if agreement_text:
+            text += f" | 결론: {agreement_text}"
+        if discussion_text:
+            text += f" | 논의: {discussion_text}"
         documents.append(
             EmbeddedDocument(
                 document_id=doc_id,

--- a/tests/test_application_embedding.py
+++ b/tests/test_application_embedding.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 from app.core.errors import AppServiceError
 from app.domains.meeting_analysis.schemas import (
     Application,
+    ApplicationTimelineItem,
     EmbeddedDocument,
     MeetingAnalysis,
     MeetingAnalysisResult,
@@ -117,6 +118,172 @@ class TestBuildEmbeddingDocuments:
         assert "근거: 응답 지연을 줄인다." in docs[0].text
         assert "DB 부하를 줄인다." in docs[0].text
         assert "트래픽 급증 시 안정성을 높인다." in docs[0].text
+
+    def test_timeline_context_uses_agreement_and_discussion_content(self):
+        """임베딩 텍스트에는 적용합의와 대안논의 content만 보조 맥락으로 반영한다."""
+        application = Application(
+            application_title="전사 병합 로직 보강",
+            application_reasons=["화자 매핑 누락을 줄인다."],
+            timeline=[
+                ApplicationTimelineItem(
+                    timestamp="00:00:01",
+                    step="이슈제기",
+                    member_id=1,
+                    content="Speaker 0만 표시되는 문제가 제기됨",
+                    utterance="아직도 Speaker 0으로 나오는데요",
+                ),
+                ApplicationTimelineItem(
+                    timestamp="00:00:10",
+                    step="대안논의",
+                    member_id=2,
+                    content="WebSocket 발화 로그와 STT 전사를 순서 기반으로 병합",
+                    utterance="웹소켓 로그랑 STT를 같이 보면 되겠습니다",
+                ),
+                ApplicationTimelineItem(
+                    timestamp="00:00:20",
+                    step="적용합의",
+                    member_id=3,
+                    content="member_id 기준으로 최종 전사 화자 보정",
+                    utterance="member_id로 대치해서 저장합시다",
+                ),
+            ],
+        )
+
+        docs = build_embedding_documents("mtg-timeline", _make_result([application]))
+
+        assert "결론: member_id 기준으로 최종 전사 화자 보정" in docs[0].text
+        assert (
+            "논의: WebSocket 발화 로그와 STT 전사를 순서 기반으로 병합" in docs[0].text
+        )
+        assert "Speaker 0만 표시되는 문제가 제기됨" not in docs[0].text
+        assert "member_id로 대치해서 저장합시다" not in docs[0].text
+
+    def test_timeline_context_falls_back_when_only_issue_step_exists(self):
+        """이슈제기만 있으면 timeline 맥락을 추가하지 않는다."""
+        application = Application(
+            application_title="전사 병합 로직 보강",
+            application_reasons=["화자 매핑 누락을 줄인다."],
+            timeline=[
+                ApplicationTimelineItem(
+                    timestamp="00:00:01",
+                    step="이슈제기",
+                    member_id=1,
+                    content="Speaker 0만 표시되는 문제가 제기됨",
+                    utterance="아직도 Speaker 0으로 나오는데요",
+                )
+            ],
+        )
+
+        docs = build_embedding_documents("mtg-issue-only", _make_result([application]))
+
+        assert "결론:" not in docs[0].text
+        assert "논의:" not in docs[0].text
+        assert "Speaker 0만 표시되는 문제가 제기됨" not in docs[0].text
+
+    def test_timeline_context_is_truncated(self):
+        """timeline 맥락은 과도하게 길어지지 않도록 제한한다."""
+        long_content = "가" * 500
+        application = Application(
+            application_title="긴 타임라인 처리",
+            application_reasons=["임베딩 노이즈를 줄인다."],
+            timeline=[
+                ApplicationTimelineItem(
+                    timestamp="00:00:20",
+                    step="적용합의",
+                    member_id=3,
+                    content=long_content,
+                    utterance="원문",
+                ),
+            ],
+        )
+
+        docs = build_embedding_documents("mtg-long", _make_result([application]))
+
+        assert f"결론: {'가' * 400}" in docs[0].text
+        assert "가" * 401 not in docs[0].text
+
+    def test_timeline_context_uses_remaining_budget_for_discussion(self):
+        """적용합의가 예산을 먼저 쓰고 대안논의는 남은 길이만 반영된다."""
+        agreement_content = "가" * 300
+        discussion_content = "나" * 300
+        application = Application(
+            application_title="타임라인 예산 처리",
+            application_reasons=["임베딩 텍스트 길이를 제한한다."],
+            timeline=[
+                ApplicationTimelineItem(
+                    timestamp="00:00:10",
+                    step="대안논의",
+                    member_id=2,
+                    content=discussion_content,
+                    utterance="논의 원문",
+                ),
+                ApplicationTimelineItem(
+                    timestamp="00:00:20",
+                    step="적용합의",
+                    member_id=3,
+                    content=agreement_content,
+                    utterance="합의 원문",
+                ),
+            ],
+        )
+
+        docs = build_embedding_documents("mtg-budget", _make_result([application]))
+
+        assert f"결론: {agreement_content}" in docs[0].text
+        assert f"논의: {'나' * 100}" in docs[0].text
+        assert "나" * 101 not in docs[0].text
+
+    def test_timeline_context_uses_discussion_without_agreement(self):
+        """적용합의가 없어도 대안논의 content는 논의 맥락으로 반영한다."""
+        application = Application(
+            application_title="대안논의 기반 적용사항",
+            application_reasons=["구체적인 구현 방향을 보강한다."],
+            timeline=[
+                ApplicationTimelineItem(
+                    timestamp="00:00:10",
+                    step="대안논의",
+                    member_id=2,
+                    content="Redis 캐시를 우선 도입하고 만료 정책을 적용",
+                    utterance="Redis를 먼저 넣고 TTL도 정하겠습니다",
+                )
+            ],
+        )
+
+        docs = build_embedding_documents(
+            "mtg-discussion-only",
+            _make_result([application]),
+        )
+
+        assert "결론:" not in docs[0].text
+        assert "논의: Redis 캐시를 우선 도입하고 만료 정책을 적용" in docs[0].text
+
+    def test_timeline_context_skips_blank_content(self):
+        """공백 content는 timeline 맥락에 반영하지 않는다."""
+        application = Application(
+            application_title="공백 타임라인 처리",
+            application_reasons=["빈 맥락을 제외한다."],
+            timeline=[
+                ApplicationTimelineItem(
+                    timestamp="00:00:20",
+                    step="적용합의",
+                    member_id=3,
+                    content="   ",
+                    utterance="공백",
+                ),
+                ApplicationTimelineItem(
+                    timestamp="00:00:30",
+                    step="대안논의",
+                    member_id=2,
+                    content="",
+                    utterance="빈 문자열",
+                ),
+            ],
+        )
+
+        docs = build_embedding_documents("mtg-blank", _make_result([application]))
+
+        assert "결론:" not in docs[0].text
+        assert "논의:" not in docs[0].text
 
 
 def _mock_embedding(n: int, dim: int = 768) -> list[list[float]]:


### PR DESCRIPTION
## ✨ 작업 개요
적용사항 임베딩 텍스트에 timeline의 적용합의/대안논의 맥락을 제한적으로 반영해 커밋 매칭에 사용할 적용사항 컨텍스트를 보강했습니다.

## 📄 작업 내용
- application embedding text에 timeline content를 추가했습니다.
  - `적용합의` content → `결론:`
  - `대안논의` content → `논의:`
- 임베딩 노이즈 방지를 위해 아래 값은 제외했습니다.
  - `이슈제기`
  - `utterance`
  - `member_id`
  - `timestamp`
- timeline 컨텍스트는 최대 400자로 제한했습니다.
- timeline이 없거나 이슈제기만 있는 경우 기존 title/reasons 기반 동작을 유지합니다.
- 예산 분배, 단독 대안논의, 공백 content, 긴 timeline에 대한 회귀 테스트를 추가했습니다.

## 📌 관련 이슈
- close #21

## 🔌 API 변경사항 (해당 시)
- 없음
- DTO/응답 구조와 Chroma metadata 구조는 변경하지 않았습니다.

## ✅ 테스트
- `uv run pytest tests/test_application_embedding.py`
- `uv run ruff format --check app/domains/meeting_analysis/services/embedding.py tests/test_application_embedding.py`
- `uv run ruff check app/domains/meeting_analysis/services/embedding.py tests/test_application_embedding.py`
- `uv run pytest`

## 💬 기타 사항
- 기존 회의 임베딩은 그대로 유지됩니다.
- timeline 반영 효과가 필요한 기존 회의는 회의 단위로 `/api/meeting-analysis/embeddings`를 다시 호출하면 갱신됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 미팅 분석 임베딩 문서에 합의 및 논의 내용 추가

## 테스트
* 타임라인 컨텍스트 통합에 대한 포괄적인 테스트 커버리지 확대

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhyLog-App/Whylog-AI/pull/57)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->