### PR TITLE
[improve/#54] 커밋 파일 경로 기반 module token 보강

### DIFF
--- a/app/domains/commit/services/summarize.py
+++ b/app/domains/commit/services/summarize.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
+import re
 from dataclasses import dataclass
+from pathlib import PurePosixPath
 
 from google import genai
 from google.genai import errors as genai_errors
@@ -55,6 +57,64 @@ SUMMARY_PROMPT = """
 
 
 VALID_DIRECTIONS = {"add", "remove", "modify", "migrate"}
+PATH_TOKEN_STOPWORDS = {
+    "api",
+    "app",
+    "abstract",
+    "base",
+    "build",
+    "common",
+    "com",
+    "component",
+    "components",
+    "config",
+    "constant",
+    "constants",
+    "controller",
+    "core",
+    "domain",
+    "domains",
+    "dto",
+    "entity",
+    "factory",
+    "gradle",
+    "helper",
+    "impl",
+    "java",
+    "kotlin",
+    "main",
+    "manager",
+    "mapper",
+    "model",
+    "org",
+    "page",
+    "pages",
+    "provider",
+    "repository",
+    "resources",
+    "service",
+    "settings",
+    "src",
+    "support",
+    "test",
+    "tests",
+    "util",
+    "utils",
+    "vo",
+    "whylog",
+}
+PATH_DIRECTORY_DENYLIST = {
+    ".git",
+    "build",
+    "dist",
+    "generated",
+    "gen",
+    "node_modules",
+    "out",
+    "target",
+}
+PATH_TOKEN_MIN_LENGTH = 2
+MODULE_TAG_MAX_COUNT = 20
 
 
 @dataclass
@@ -113,6 +173,59 @@ def _build_commit_input(message: str, changed_file_list: list[ChangedFile]) -> s
         f"[{f.file_name}]\n{f.changed_code}" for f in changed_file_list
     )
     return f"커밋 메시지: {message}\n\n변경 파일:\n{files_text}"
+
+
+def _split_path_token(value: str) -> set[str]:
+    raw_parts = re.split(r"[^A-Za-z0-9가-힣]+", value)
+    split_parts: set[str] = set()
+    for part in raw_parts:
+        if not part:
+            continue
+        split_parts.update(
+            re.findall(
+                r"[A-Z]+(?=[A-Z][a-z]|\d|\b)|[A-Z]?[a-z]+|\d+|[가-힣]+",
+                part,
+            )
+            or [part]
+        )
+    return {part.lower() for part in split_parts if part}
+
+
+def _extract_path_module_tokens(changed_file_list: list[ChangedFile]) -> list[str]:
+    tokens: set[str] = set()
+    for changed_file in sorted(changed_file_list, key=lambda f: f.file_name):
+        path = PurePosixPath(changed_file.file_name)
+        path_parts = [part.lower() for part in path.parts]
+        if any(part in PATH_DIRECTORY_DENYLIST for part in path_parts):
+            continue
+        for part in path.parts:
+            if part in {"/", ".", ".."}:
+                continue
+            stem = PurePosixPath(part).stem
+            for token in _split_path_token(stem):
+                if len(token) < PATH_TOKEN_MIN_LENGTH:
+                    continue
+                if token in PATH_TOKEN_STOPWORDS:
+                    continue
+                tokens.add(token)
+    return sorted(tokens)
+
+
+def _merge_unique_tokens(
+    *token_groups: list[str], limit: int = MODULE_TAG_MAX_COUNT
+) -> list[str]:
+    merged: list[str] = []
+    seen: set[str] = set()
+    for group in token_groups:
+        for token in group:
+            normalized = token.strip().lower()
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            merged.append(normalized)
+            if len(merged) >= limit:
+                return merged
+    return merged
 
 
 async def _call_gemini(
@@ -209,6 +322,8 @@ async def store_commit_embedding(
     # 1) LLM으로 구조화 텍스트 생성
     raw_text = await _call_gemini(client, EMBEDDING_PROMPT, commit_input, timeout=60.0)
     parsed = _parse_embedding_response(raw_text)
+    path_module_tokens = _extract_path_module_tokens(changed_file_list)
+    module_tags = _merge_unique_tokens(parsed.module_tags, path_module_tokens)
 
     # 2) 스펙에 맞는 임베딩용 텍스트 조합
     commit_subject = message.split("\n", 1)[0].strip()
@@ -218,8 +333,8 @@ async def store_commit_embedding(
         text_parts.append(f"기술키워드: {','.join(parsed.tech_keywords)}")
     if parsed.directions:
         text_parts.append(f"변경방향: {','.join(parsed.directions)}")
-    if parsed.module_tags:
-        text_parts.append(f"파일맥락: {','.join(parsed.module_tags)}")
+    if module_tags:
+        text_parts.append(f"파일맥락: {','.join(module_tags)}")
     embedding_text = f"title: {title} | text: {' | '.join(text_parts)}"
 
     # 3) 임베딩 벡터 생성
@@ -234,7 +349,7 @@ async def store_commit_embedding(
         "repository_id": repository_id,
         "direction": ",".join(parsed.directions),
         "tech_keywords_csv": ",".join(parsed.tech_keywords),
-        "module_tags_csv": ",".join(parsed.module_tags),
+        "module_tags_csv": ",".join(module_tags),
     }
     if commit_id is not None:
         metadata["commit_id"] = commit_id

--- a/tests/test_application_commit_matching.py
+++ b/tests/test_application_commit_matching.py
@@ -17,7 +17,10 @@ from app.domains.commit.services.matching import (
     _to_application_entries,
     match_applications_with_commits,
 )
-from app.domains.commit.services.summarize import generate_embedding_text
+from app.domains.commit.services.summarize import (
+    _extract_path_module_tokens,
+    generate_embedding_text,
+)
 from app.main import app
 
 
@@ -547,6 +550,85 @@ class TestApplicationCommitMatchingEndpoint:
 
 
 class TestCommitAnalyzeHashMetadata:
+    def test_extract_path_module_tokens_filters_project_structure_words(self):
+        tokens = _extract_path_module_tokens(
+            [
+                ChangedFile(
+                    file_name=(
+                        "src/main/java/com/whylog/domain/team/service/"
+                        "TeamImageService.java"
+                    ),
+                    changed_code="+class TeamImageService {}",
+                ),
+                ChangedFile(
+                    file_name=(
+                        "src/main/java/com/whylog/domain/user/controller/"
+                        "UserProfileController.java"
+                    ),
+                    changed_code="+class UserProfileController {}",
+                ),
+            ]
+        )
+
+        assert {"team", "image", "user", "profile"}.issubset(set(tokens))
+        assert "src" not in tokens
+        assert "main" not in tokens
+        assert "java" not in tokens
+        assert "domain" not in tokens
+        assert "service" not in tokens
+        assert "controller" not in tokens
+        assert "whylog" not in tokens
+
+    def test_extract_path_module_tokens_filters_split_architecture_words(self):
+        tokens = _extract_path_module_tokens(
+            [
+                ChangedFile(
+                    file_name=(
+                        "src/main/java/com/whylog/domain/team/repository/"
+                        "BaseTeamRepositoryImpl.java"
+                    ),
+                    changed_code="+interface BaseTeamRepositoryImpl {}",
+                )
+            ]
+        )
+
+        assert tokens == ["team"]
+
+    def test_extract_path_module_tokens_splits_acronyms(self):
+        tokens = _extract_path_module_tokens(
+            [
+                ChangedFile(
+                    file_name=(
+                        "src/main/java/com/whylog/domain/user/"
+                        "URLParserXMLConfigController.java"
+                    ),
+                    changed_code="+class URLParserXMLConfigController {}",
+                )
+            ]
+        )
+
+        assert {"url", "parser", "xml", "user"}.issubset(set(tokens))
+        assert "config" not in tokens
+        assert "controller" not in tokens
+
+    def test_extract_path_module_tokens_skips_generated_directories(self):
+        tokens = _extract_path_module_tokens(
+            [
+                ChangedFile(
+                    file_name="build/generated/source/team/TeamClient.java",
+                    changed_code="+class TeamClient {}",
+                ),
+                ChangedFile(
+                    file_name="src/main/java/com/whylog/domain/user/UserService.java",
+                    changed_code="+class UserService {}",
+                ),
+            ]
+        )
+
+        assert "team" not in tokens
+        assert "client" not in tokens
+        assert "user" in tokens
+
     @pytest.mark.asyncio
     async def test_analyze_commit_passes_commit_hash_to_background_embedding(self):
         background_tasks = BackgroundTasks()
@@ -623,3 +705,105 @@ class TestCommitAnalyzeHashMetadata:
         assert kwargs["metadatas"][0]["commit_hash"] == "b8fd9ad"
         assert kwargs["metadatas"][0]["commit_message"] == "feat: API 구현"
         assert kwargs["metadatas"][0]["repository_id"] == 1
+
+    @pytest.mark.asyncio
+    async def test_generate_embedding_text_merges_llm_modules_with_path_tokens(self):
+        collection = MagicMock()
+
+        with (
+            patch(
+                "app.domains.commit.services.summarize._get_client",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "app.domains.commit.services.summarize._call_gemini",
+                new_callable=AsyncMock,
+                return_value=(
+                    "변경요약: 팀 이미지 업로드 API 명세를 보강했습니다.\n"
+                    "기술키워드: Swagger,OpenAPI\n"
+                    "변경방향: modify\n"
+                    "파일맥락: swagger,team"
+                ),
+            ),
+            patch(
+                "app.domains.commit.services.summarize._generate_embedding",
+                new_callable=AsyncMock,
+                return_value=[0.1, 0.2, 0.3],
+            ),
+            patch(
+                "app.domains.commit.services.summarize.get_commit_collection",
+                return_value=collection,
+            ),
+        ):
+            await generate_embedding_text(
+                commit_hash="b8fd9ad",
+                repository_id=1,
+                message="docs: 팀 이미지 업로드 Swagger 명세 보강",
+                changed_file_list=[
+                    ChangedFile(
+                        file_name=(
+                            "src/main/java/com/whylog/domain/team/controller/"
+                            "TeamImageController.java"
+                        ),
+                        changed_code='+@Operation(summary = "팀 이미지 업로드")',
+                    )
+                ],
+                commit_id=1,
+            )
+
+        _, kwargs = collection.upsert.call_args
+        document = kwargs["documents"][0]
+        module_tags = set(kwargs["metadatas"][0]["module_tags_csv"].split(","))
+        assert {"swagger", "team", "image"}.issubset(module_tags)
+        assert "controller" not in module_tags
+        assert "파일맥락:" in document
+        assert "image" in document
+
+    @pytest.mark.asyncio
+    async def test_generate_embedding_text_caps_module_tags_with_llm_priority(self):
+        collection = MagicMock()
+        changed_files = [
+            ChangedFile(
+                file_name=f"src/main/java/com/whylog/domain/domain{i}/Domain{i}.java",
+                changed_code=f"+class Domain{i} {{}}",
+            )
+            for i in range(30)
+        ]
+
+        with (
+            patch(
+                "app.domains.commit.services.summarize._get_client",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "app.domains.commit.services.summarize._call_gemini",
+                new_callable=AsyncMock,
+                return_value=(
+                    "변경요약: 여러 도메인 파일을 수정했습니다.\n"
+                    "기술키워드: Spring\n"
+                    "변경방향: modify\n"
+                    "파일맥락: billing,team"
+                ),
+            ),
+            patch(
+                "app.domains.commit.services.summarize._generate_embedding",
+                new_callable=AsyncMock,
+                return_value=[0.1, 0.2, 0.3],
+            ),
+            patch(
+                "app.domains.commit.services.summarize.get_commit_collection",
+                return_value=collection,
+            ),
+        ):
+            await generate_embedding_text(
+                commit_hash="many-files",
+                repository_id=1,
+                message="chore: 여러 도메인 파일 수정",
+                changed_file_list=changed_files,
+                commit_id=1,
+            )
+
+        _, kwargs = collection.upsert.call_args
+        module_tags = kwargs["metadatas"][0]["module_tags_csv"].split(",")
+        assert module_tags[:2] == ["billing", "team"]
+        assert len(module_tags) == 20


### PR DESCRIPTION
## ✨ 작업 개요
커밋 임베딩 생성 시 LLM이 추출한 파일맥락에 실제 변경 파일 경로 기반 도메인 토큰을 병합해 적용사항-커밋 매칭의 파일/모듈 맥락 점수를 보강했습니다.

## 📄 작업 내용
- 커밋 변경 파일 경로에서 도메인 토큰을 추출하도록 로직 추가
  - camelCase, acronym, 숫자/한글 토큰 분리 지원
  - `src`, `main`, `java`, `controller`, `service`, `repository`, `impl`, `whylog` 등 구조성 단어 제거
  - `build`, `generated`, `node_modules`, `target` 등 생성/빌드 경로 제외
- LLM 파일맥락과 경로 기반 토큰을 병합해 기존 `파일맥락` 텍스트와 `module_tags_csv`에 저장
- 토큰은 소문자 기준으로 중복 제거하고 최대 20개로 제한
- LLM이 추출한 파일맥락을 우선 보존하고, 부족한 부분만 경로 토큰으로 보강
- 관련 테스트 보강
  - 구조성 단어 제거
  - 파일명 split 이후 stopword 제거
  - acronym 분리
  - generated 경로 제외
  - LLM 파일맥락 + path token 병합
  - token cap 및 LLM 우선순위 검증

## 📌 관련 이슈
- close #54

## 🔌 API 변경사항 (해당 시)
없음.

## 💬 기타 사항
- Chroma metadata 필드는 추가하지 않고 기존 `module_tags_csv`만 보강했습니다.
- 기존 커밋 임베딩은 재생성 전까지 LLM 파일맥락만 사용하고, 신규 임베딩부터 경로 토큰이 함께 반영됩니다.
- 기존 커밋까지 동일 기준으로 맞추려면 커밋 임베딩 재생성이 필요합니다.

## ✅ 검증
- `uv run ruff check app/domains/commit/services/summarize.py tests/test_application_commit_matching.py`
- `uv run ruff format --check app/domains/commit/services/summarize.py tests/test_application_commit_matching.py`
- `uv run pytest tests/test_application_commit_matching.py tests/test_application_commit_matching_scoring.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 커밋 분석 시 파일 경로 기반 모듈 태그 추출 개선
  * 커밋 메타데이터 정확도 및 컨텍스트 정보 향상

* **테스트**
  * 경로 토큰 추출 및 모듈 태그 병합 로직에 대한 포괄적 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhyLog-App/Whylog-AI/pull/58)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->