### PR TITLE
[improve/#53] 커밋 타입 기반 적용사항-커밋 매칭 점수 보정

### DIFF
--- a/app/domains/commit/schemas.py
+++ b/app/domains/commit/schemas.py
@@ -108,6 +108,7 @@ class MatchScoreBreakdown(BaseModel):
     semantic: int = Field(description="의미 유사성 점수(0~50)")
     keyword: int = Field(description="기술 키워드 일치도 점수(0~30)")
     context: int = Field(description="파일/모듈 맥락 점수(0~20)")
+    type_bonus: int = Field(default=0, description="커밋 타입 일치 보너스")
     penalty: int = Field(description="보정 감점 합계(0~20)")
     total: int = Field(description="최종 신뢰도 점수(0~100)")
 

--- a/app/domains/commit/services/matching.py
+++ b/app/domains/commit/services/matching.py
@@ -98,6 +98,8 @@ def _build_recommendation_reason(
     ]
     if score.penalty:
         parts.append(f"보정 감점 {score.penalty}점")
+    if score.type_bonus:
+        parts.append(f"커밋 타입 가산 +{score.type_bonus}점")
     parts.append(f"겹친 키워드: {_format_tokens(keyword_overlap)}")
     parts.append(f"겹친 모듈: {_format_tokens(module_overlap)}")
     return ". ".join(parts) + "."
@@ -337,6 +339,7 @@ def _build_match_record(
             semantic=score.semantic,
             keyword=score.keyword,
             context=score.context,
+            type_bonus=score.type_bonus,
             penalty=score.penalty,
             total=score.total,
         ),

--- a/app/domains/meeting_analysis/services/matching_scoring.py
+++ b/app/domains/meeting_analysis/services/matching_scoring.py
@@ -96,10 +96,17 @@ _ABSTRACT_COMMIT_WORDS = {
     "change",
     "chore",
     "cleanup",
+    "doc",
+    "docs",
+    "feature",
+    "feat",
     "fix",
+    "build",
     "minor",
     "patch",
     "refactor",
+    "test",
+    "tests",
     "update",
     "수정",
     "정리",
@@ -210,6 +217,13 @@ _FIX_APPLICATION_WORDS = {
     "에러",
     "예외",
     "오류",
+}
+_FIX_ACTION_WORDS = {
+    "fix",
+    "resolve",
+    "고침",
+    "수정",
+    "해결",
 }
 _REFACTOR_APPLICATION_WORDS = {
     "refactor",
@@ -322,7 +336,9 @@ def infer_application_commit_types(application_text: str) -> set[CommitType]:
 
     if tokens & _DOCS_APPLICATION_WORDS:
         expected_types.update({"docs", "chore"})
-    if not expected_types and tokens & _FIX_APPLICATION_WORDS:
+    if tokens & _FIX_APPLICATION_WORDS and (
+        not expected_types or tokens & _FIX_ACTION_WORDS
+    ):
         expected_types.add("fix")
     if tokens & _REFACTOR_APPLICATION_WORDS:
         expected_types.add("refactor")
@@ -331,11 +347,22 @@ def infer_application_commit_types(application_text: str) -> set[CommitType]:
     return expected_types
 
 
-def score_commit_type_match(application_text: str, commit_message: str) -> int:
+def score_commit_type_match(
+    application_text: str,
+    commit_message: str,
+    commit_text: str = "",
+) -> int:
     commit_type = extract_commit_type(commit_message)
     if not commit_type:
         return 0
     expected_types = infer_application_commit_types(application_text)
+    commit_tokens = extract_text_tokens(f"{commit_message} {commit_text}")
+    if (
+        commit_type == "chore"
+        and "docs" in expected_types
+        and not commit_tokens & _DOCS_APPLICATION_WORDS
+    ):
+        return 0
     if commit_type in expected_types:
         return _TYPE_BONUS
     return 0
@@ -561,9 +588,10 @@ def calculate_match_score(payload: ScoringInput) -> ScoreBreakdown:
     type_bonus = score_commit_type_match(
         payload.application_text,
         payload.commit_message,
+        payload.commit_text,
     )
     penalty = 0
-    if type_bonus == 0 and is_abstract_commit_message(payload.commit_message):
+    if is_abstract_commit_message(payload.commit_message):
         penalty += 10
     if is_ambiguous_application(
         payload.application_text,

--- a/app/domains/meeting_analysis/services/matching_scoring.py
+++ b/app/domains/meeting_analysis/services/matching_scoring.py
@@ -5,9 +5,12 @@ from dataclasses import dataclass
 from typing import Literal
 
 MatchStatus = Literal["APPLIED", "PARTIAL", "UNAPPLIED"]
+CommitType = Literal["feat", "fix", "docs", "refactor", "test", "build", "chore"]
 
 _TOKEN_PATTERN = re.compile(r"[A-Za-z][A-Za-z0-9._/-]{1,}|[가-힣]{2,}")
 _PATH_LIKE_PATTERN = re.compile(r"[A-Za-z0-9._/-]+")
+_COMMIT_TYPE_PATTERN = re.compile(r"^\s*([a-zA-Z]+)(?:\([^)]+\))?!?:")
+_TYPE_BONUS = 3
 
 _GENERIC_STOPWORDS = {
     "a",
@@ -170,12 +173,73 @@ _LABEL_ALIASES = {
     "폐기": "negative",
 }
 
+_COMMIT_TYPE_ALIASES: dict[str, CommitType] = {
+    "feature": "feat",
+    "feat": "feat",
+    "fix": "fix",
+    "bugfix": "fix",
+    "docs": "docs",
+    "doc": "docs",
+    "documentation": "docs",
+    "refactor": "refactor",
+    "test": "test",
+    "tests": "test",
+    "build": "build",
+    "chore": "chore",
+}
+
+_DOCS_APPLICATION_WORDS = {
+    "docs",
+    "documentation",
+    "openapi",
+    "swagger",
+    "문서",
+    "문서화",
+    "명세",
+    "스웨거",
+}
+_FIX_APPLICATION_WORDS = {
+    "bug",
+    "bugfix",
+    "error",
+    "exception",
+    "fix",
+    "issue",
+    "문제",
+    "버그",
+    "에러",
+    "예외",
+    "오류",
+}
+_REFACTOR_APPLICATION_WORDS = {
+    "refactor",
+    "refactoring",
+    "리팩토링",
+}
+_FEATURE_APPLICATION_WORDS = {
+    "add",
+    "create",
+    "enable",
+    "feature",
+    "implement",
+    "introduce",
+    "support",
+    "구현",
+    "도입",
+    "생성",
+    "연동",
+    "적용",
+    "지원",
+    "추가",
+}
+
 
 @dataclass(frozen=True)
 class ScoreBreakdown:
     semantic: int
     keyword: int
     context: int
+    type_bonus: int
     penalty: int
     total: int
     status: MatchStatus
@@ -242,6 +306,39 @@ def normalize_direction_labels(*values: str | None) -> set[str]:
             if label:
                 labels.add(label)
     return labels
+
+
+def extract_commit_type(commit_message: str) -> CommitType | None:
+    match = _COMMIT_TYPE_PATTERN.match(commit_message or "")
+    if not match:
+        return None
+    raw_type = _normalize_token(match.group(1))
+    return _COMMIT_TYPE_ALIASES.get(raw_type)
+
+
+def infer_application_commit_types(application_text: str) -> set[CommitType]:
+    tokens = extract_text_tokens(application_text)
+    expected_types: set[CommitType] = set()
+
+    if tokens & _DOCS_APPLICATION_WORDS:
+        expected_types.update({"docs", "chore"})
+    if not expected_types and tokens & _FIX_APPLICATION_WORDS:
+        expected_types.add("fix")
+    if tokens & _REFACTOR_APPLICATION_WORDS:
+        expected_types.add("refactor")
+    if tokens & _FEATURE_APPLICATION_WORDS:
+        expected_types.add("feat")
+    return expected_types
+
+
+def score_commit_type_match(application_text: str, commit_message: str) -> int:
+    commit_type = extract_commit_type(commit_message)
+    if not commit_type:
+        return 0
+    expected_types = infer_application_commit_types(application_text)
+    if commit_type in expected_types:
+        return _TYPE_BONUS
+    return 0
 
 
 def extract_text_tokens(text: str) -> set[str]:
@@ -452,6 +549,7 @@ def calculate_match_score(payload: ScoringInput) -> ScoreBreakdown:
             semantic=semantic,
             keyword=keyword,
             context=context,
+            type_bonus=0,
             penalty=0,
             total=0,
             status="UNAPPLIED",
@@ -460,8 +558,12 @@ def calculate_match_score(payload: ScoringInput) -> ScoreBreakdown:
         )
 
     base_score = semantic + keyword + context
+    type_bonus = score_commit_type_match(
+        payload.application_text,
+        payload.commit_message,
+    )
     penalty = 0
-    if is_abstract_commit_message(payload.commit_message):
+    if type_bonus == 0 and is_abstract_commit_message(payload.commit_message):
         penalty += 10
     if is_ambiguous_application(
         payload.application_text,
@@ -470,11 +572,12 @@ def calculate_match_score(payload: ScoringInput) -> ScoreBreakdown:
     ):
         penalty += 10
 
-    total = max(0, min(100, base_score - penalty))
+    total = max(0, min(100, base_score + type_bonus - penalty))
     return ScoreBreakdown(
         semantic=semantic,
         keyword=keyword,
         context=context,
+        type_bonus=type_bonus,
         penalty=penalty,
         total=total,
         status=resolve_match_status(total),

--- a/tests/test_application_commit_matching.py
+++ b/tests/test_application_commit_matching.py
@@ -177,7 +177,9 @@ class TestApplicationCommitMatchingService:
         assert item.recommended_commits[0].confidence >= 70
         assert item.recommended_commits[0].reason.endswith(".")
         assert "총" in item.recommended_commits[0].score_detail
+        assert "커밋 타입 가산 +3점" in item.recommended_commits[0].score_detail
         assert "겹친 키워드" in item.recommended_commits[0].score_detail
+        assert item.recommended_commits[0].score_breakdown.type_bonus == 3
         assert item.recommended_commits[1].commit_hash == "h2"
         assert item.recommended_commits[0].confidence >= (
             item.recommended_commits[1].confidence

--- a/tests/test_application_commit_matching_scoring.py
+++ b/tests/test_application_commit_matching_scoring.py
@@ -2,10 +2,13 @@ from app.domains.meeting_analysis.services.matching_scoring import (
     ScoringInput,
     build_connection_reason,
     calculate_match_score,
+    extract_commit_type,
     extract_direction_labels_from_text,
     extract_module_tokens,
     extract_tech_keywords,
+    infer_application_commit_types,
     normalize_direction_labels,
+    score_commit_type_match,
     score_context_match,
     score_keyword_match,
 )
@@ -227,3 +230,73 @@ class TestTotalScorePolicy:
 
         assert reason.endswith(".")
         assert len(reason) > 10
+
+
+class TestCommitTypeScorePolicy:
+    def test_extract_commit_type_accepts_scope_and_breaking_marker(self):
+        assert extract_commit_type("feat(auth)!: 로그인 API 추가") == "feat"
+        assert extract_commit_type("docs: Swagger 명세 보강") == "docs"
+        assert extract_commit_type("unknown: 기타 작업") is None
+
+    def test_application_commit_type_inference_allows_docs_and_chore(self):
+        expected_types = infer_application_commit_types(
+            "Swagger 에러 응답 예시 문서화 및 OpenAPI 명세 정리"
+        )
+
+        assert expected_types == {"docs", "chore"}
+
+    def test_type_match_adds_small_positive_bonus(self):
+        bonus = score_commit_type_match(
+            "팀 목록 조회 API 구현",
+            "feat: 본인 소속 팀 목록 조회 api 구현",
+        )
+
+        assert bonus == 3
+
+    def test_type_mismatch_does_not_apply_penalty(self):
+        payload = _make_payload(
+            distance=0.30,  # semantic 35
+            application_text="Swagger 에러 응답 예시 문서화",
+            commit_message="feat: Swagger 에러 응답 예시 지원",
+            application_keywords={"swagger", "에러"},
+            commit_keywords={"swagger", "에러"},
+            application_modules={"swagger"},
+            commit_modules={"swagger"},
+        )
+        score = calculate_match_score(payload)
+
+        assert score.type_bonus == 0
+        assert score.penalty == 0
+        assert score.total == 70
+
+    def test_chore_commit_can_match_documentation_application(self):
+        payload = _make_payload(
+            distance=0.30,  # semantic 35
+            application_text="Swagger 에러 응답 예시 문서화",
+            commit_message="chore: @ApiErrorCodeExample 적용",
+            application_keywords={"swagger", "에러"},
+            commit_keywords={"swagger", "에러"},
+            application_modules={"swagger"},
+            commit_modules={"swagger"},
+        )
+        score = calculate_match_score(payload)
+
+        assert score.type_bonus == 3
+        assert score.penalty == 0
+        assert score.total == 73
+
+    def test_type_bonus_does_not_rescue_goal_mismatch(self):
+        payload = _make_payload(
+            distance=0.90,  # semantic 5
+            application_text="팀 목록 조회 API 구현",
+            commit_message="feat: 팀 목록 조회 API 추가",
+            application_keywords={"team"},
+            commit_keywords={"team"},
+            application_modules={"team"},
+            commit_modules={"auth"},
+        )
+        score = calculate_match_score(payload)
+
+        assert score.is_goal_mismatch is True
+        assert score.type_bonus == 0
+        assert score.total == 0

--- a/tests/test_application_commit_matching_scoring.py
+++ b/tests/test_application_commit_matching_scoring.py
@@ -273,6 +273,7 @@ class TestCommitTypeScorePolicy:
         payload = _make_payload(
             distance=0.30,  # semantic 35
             application_text="Swagger 에러 응답 예시 문서화",
+            commit_text="Swagger OpenAPI 에러 응답 예시 문서화",
             commit_message="chore: @ApiErrorCodeExample 적용",
             application_keywords={"swagger", "에러"},
             commit_keywords={"swagger", "에러"},
@@ -284,6 +285,47 @@ class TestCommitTypeScorePolicy:
         assert score.type_bonus == 3
         assert score.penalty == 0
         assert score.total == 73
+
+    def test_unrelated_chore_does_not_match_documentation_type(self):
+        bonus = score_commit_type_match(
+            "Swagger 에러 응답 예시 문서화",
+            "chore: spring boot version update",
+            "Spring Boot 의존성을 업데이트했습니다.",
+        )
+
+        assert bonus == 0
+
+    def test_abstract_commit_penalty_is_not_exempted_by_type_bonus(self):
+        payload = _make_payload(
+            distance=0.30,  # semantic 35
+            application_text="Swagger 응답 예시 문서화",
+            commit_text="Swagger 문서",
+            commit_message="docs: update",
+            application_keywords={"swagger", "문서"},
+            commit_keywords={"swagger", "문서"},
+            application_modules={"swagger"},
+            commit_modules={"swagger"},
+        )
+        score = calculate_match_score(payload)
+
+        assert score.type_bonus == 3
+        assert score.penalty == 10
+        assert score.total == 63
+
+    def test_mixed_documentation_fix_intent_includes_fix_when_action_exists(self):
+        expected_types = infer_application_commit_types("Swagger 문서화 오류 수정")
+
+        assert expected_types == {"docs", "chore", "fix"}
+
+    def test_mixed_documentation_feature_intent_keeps_docs_and_feat(self):
+        expected_types = infer_application_commit_types("API 명세 구현")
+
+        assert expected_types == {"docs", "chore", "feat"}
+
+    def test_mixed_refactor_documentation_intent_keeps_both_types(self):
+        expected_types = infer_application_commit_types("리팩토링 후 Swagger 정리")
+
+        assert expected_types == {"docs", "chore", "refactor"}
 
     def test_type_bonus_does_not_rescue_goal_mismatch(self):
         payload = _make_payload(


### PR DESCRIPTION
## ✨ 작업 개요
적용사항-커밋 매칭 점수에 커밋 메시지 타입(`feat`, `fix`, `docs`, `chore`, `refactor` 등)을 소폭 반영해 같은 키워드를 공유하는 커밋의 추천 순위를 더 정교하게 조정했습니다.

## 📄 작업 내용
- 커밋 메시지 prefix에서 commit type 추출
  - `feat(scope)!:`, `docs:`, `fix:` 등 conventional commit 형태 지원
- 적용사항 문맥에서 기대 commit type 추론
  - 구현/추가/도입/연동 → `feat`
  - 오류/버그/예외/문제 → `fix`
  - Swagger/OpenAPI/문서/명세 → `docs`, `chore`
  - 리팩토링 → `refactor`
- commit type이 적용사항 성격과 일치하면 `+3` 보너스 적용
- 타입이 불일치해도 감점하지 않도록 처리
  - 추론 오류로 정답 커밋이 밀리는 상황 방지
- goal mismatch 판정은 타입 보너스로 구제하지 않도록 기존 안전장치 유지
- 타입이 맞는 추상 커밋 메시지는 추상 커밋 페널티를 면제
  - 예: `chore: @ApiErrorCodeExample 적용`이 Swagger 문서화 적용사항과 맞는 경우

## 📌 관련 이슈
- close #53

## 🔌 API 변경사항 (해당 시)
없음.

## 💬 기타 사항
- 응답 DTO 필드는 변경하지 않았습니다.
- `score_breakdown` 구조도 유지했습니다.
- 타입 보정은 필터가 아니라 작은 가산점이라 관련 커밋 누락 위험을 줄이는 방향입니다.

## ✅ 검증
- `uv run ruff check app/domains/meeting_analysis/services/matching_scoring.py tests/test_application_commit_matching_scoring.py`
- `uv run ruff format --check app/domains/meeting_analysis/services/matching_scoring.py tests/test_application_commit_matching_scoring.py`
- `uv run pytest tests/test_application_commit_matching_scoring.py tests/test_application_commit_matching.py`
