### PR TITLE
[improve/#69] 적용사항 timeline 근거 의도 정렬 개선

### DIFF
--- a/app/domains/meeting_analysis/services/extraction.py
+++ b/app/domains/meeting_analysis/services/extraction.py
@@ -92,6 +92,19 @@ CONCRETE_APPLICATION_RULE = [
     '6. "개선하기로 함", "논의하기로 함", "준비하기로 함"처럼',
     "   대상/방법이 빠진 두루뭉술한 표현은 절대 사용하지 않는다.",
 ]
+TIMELINE_EVIDENCE_ALIGNMENT_RULE = [
+    "[타임라인 근거 정렬 규칙 - 반드시 준수]",
+    "1. timeline은 application_title/application_reasons의 핵심 작업 의도를",
+    "   직접 뒷받침하는 발화만 포함한다.",
+    "2. 같은 화면, API, 도메인명이 겹쳐도 작업 의도가 다르면",
+    "   같은 application의 timeline에 넣지 않는다.",
+    "3. '어디에 적용하는가'보다 '무엇을 바꾸기로 했는가'를 우선한다.",
+    '4. 예: "커밋 상세 페이지 로딩 스피너 컴포넌트 적용"에는',
+    '   "응답 필드명 통일" 발화를 포함하지 않는다.',
+    '5. 예: "커밋 상세 API 응답 필드명 통일"에는',
+    '   "로딩 스피너 적용" 발화를 포함하지 않는다.',
+    "6. 공통 범위 키워드만 겹치는 발화는 other_mentions로 보내거나 제외한다.",
+]
 
 APPLICATION_POLICY_PROMPT = "\n".join(
     [
@@ -124,6 +137,7 @@ APPLICATION_POLICY_PROMPT = "\n".join(
         "   member_id는 STT 데이터의 member_id 값을 사용하고, 없으면 null로 둔다.",
         "4. timeline의 content는 간략한 한 문장으로 작성한다.",
         *CONCRETE_APPLICATION_RULE,
+        *TIMELINE_EVIDENCE_ALIGNMENT_RULE,
         "------------------------------------------------------------",
         "",
         "[출력 JSON 구조]:",
@@ -217,6 +231,7 @@ APPLICATIONS_ONLY_PROMPT = "\n".join(
         "3. member_id는 STT 데이터의 member_id 값을 사용하고, 없으면 null로 둔다.",
         "4. content는 간략한 한 문장으로 작성한다.",
         *CONCRETE_APPLICATION_RULE,
+        *TIMELINE_EVIDENCE_ALIGNMENT_RULE,
         "",
         "[출력 JSON 구조]",
         "{",

--- a/tests/test_application_reason_format.py
+++ b/tests/test_application_reason_format.py
@@ -4,8 +4,11 @@ from app.domains.meeting_analysis.schemas import (
     MeetingAnalysisResult,
 )
 from app.domains.meeting_analysis.services.extraction import (
+    APPLICATION_POLICY_PROMPT,
+    APPLICATIONS_ONLY_PROMPT,
     CONCRETE_APPLICATION_RULE,
     NOUN_ENDING_REASON_RULE,
+    TIMELINE_EVIDENCE_ALIGNMENT_RULE,
     _normalize_application_reason_outputs,
     _normalize_overall_reason_outputs,
 )
@@ -25,6 +28,21 @@ class TestApplicationReasonFormat:
         assert "실제 실행/반영 단위" in joined_rule
         assert "두루뭉술한 표현은 절대 사용하지 않는다" in joined_rule
         assert "WebSocket 발화로그 기준으로 STT 화자 보정 적용" in joined_rule
+
+    def test_timeline_prompt_rule_requires_intent_aligned_evidence(self):
+        joined_rule = "\n".join(TIMELINE_EVIDENCE_ALIGNMENT_RULE)
+
+        assert "핵심 작업 의도" in joined_rule
+        assert "같은 화면, API, 도메인명이 겹쳐도" in joined_rule
+        assert "무엇을 바꾸기로 했는가" in joined_rule
+        assert "커밋 상세 페이지 로딩 스피너 컴포넌트 적용" in joined_rule
+        assert "응답 필드명 통일" in joined_rule
+
+    def test_timeline_evidence_alignment_rule_is_used_by_analysis_prompts(self):
+        for prompt in (APPLICATION_POLICY_PROMPT, APPLICATIONS_ONLY_PROMPT):
+            assert "타임라인 근거 정렬 규칙" in prompt
+            assert "같은 application의 timeline에 넣지 않는다" in prompt
+            assert "공통 범위 키워드만 겹치는 발화" in prompt
 
     def test_application_reasons_are_normalized_to_noun_endings(self):
         result = MeetingAnalysisResult(


### PR DESCRIPTION
## ✨ 작업 개요
적용사항 timeline 근거가 공통 화면/API 키워드만 보고 잘못 붙지 않도록, 실제 작업 의도 기준으로 근거 발화를 고르는 프롬프트 규칙을 추가했습니다.

## 📄 작업 내용
- timeline 근거 정렬 규칙 추가
  - 같은 화면/API/도메인명이 겹쳐도 작업 의도가 다르면 같은 application timeline에 포함하지 않도록 명시
  - "어디에 적용하는가"보다 "무엇을 바꾸기로 했는가"를 우선하도록 명시
  - 로딩 스피너 적용과 응답 필드명 통일처럼 공통 범위 키워드가 겹치는 케이스를 예시로 추가
- 전체 회의 분석/적용사항 단독 추출 프롬프트에 동일 규칙 반영
- 프롬프트 계약 테스트 추가

## ✅ 테스트
- `uv run pytest`
- `uv run ruff check`

## 💬 기타 사항
- 응답 DTO 구조 변경은 없습니다.
- 기존 분석 결과는 재분석 전까지 그대로 유지됩니다.

Closes #69


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 회의 분석의 타임라인 추출 정확도를 향상시키기 위해 근거 정렬 규칙을 강화했습니다. 이제 타임라인에는 실제 적용 의도와 직접 부합하는 발화만 포함되며, 관련성이 낮은 발화는 자동으로 분리됩니다.

* **테스트**
  * 타임라인 규칙 검증 테스트를 추가하여 개선 사항이 올바르게 적용되도록 확인했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->