### PR TITLE
[fix/#71] Deepgram 빈 전사 진단 및 WebSocket 폴백 보강

### DIFF
--- a/app/domains/transcribe/services/deepgram.py
+++ b/app/domains/transcribe/services/deepgram.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import httpx
@@ -10,6 +11,7 @@ from app.domains.transcribe.services.audio import (
 
 # Deepgram STT API 엔드포인트
 DEEPGRAM_URL = "https://api.deepgram.com/v1/listen"
+logger = logging.getLogger(__name__)
 
 # 오디오 파일 확장자 → MIME 타입 매핑
 CONTENT_TYPE_MAP = {
@@ -78,17 +80,27 @@ async def transcribe(
             status_code=502,
         )
 
-    # 응답에서 발화(utterance) 목록 추출
-    utterances = response.json().get("results", {}).get("utterances") or []
-    raw_segments = [
-        {
-            "speaker": utt.get("speaker", 0),
-            "start": utt.get("start", 0.0),
-            "end": utt.get("end", 0.0),
-            "text": utt.get("transcript", ""),
-        }
-        for utt in utterances
-    ]
+    response_payload = response.json()
+    diagnostics = _response_diagnostics(response_payload)
+    logger.info(
+        "Deepgram transcript response: audio_bytes=%s content_type=%s "
+        "utterances=%s channels=%s transcript_chars=%s words=%s",
+        len(audio_bytes),
+        content_type,
+        diagnostics["utterance_count"],
+        diagnostics["channel_count"],
+        diagnostics["transcript_chars"],
+        diagnostics["word_count"],
+    )
+    if diagnostics["utterance_count"] == 0:
+        logger.warning(
+            "Deepgram utterances empty: transcript_chars=%s words=%s",
+            diagnostics["transcript_chars"],
+            diagnostics["word_count"],
+        )
+        logger.warning("Deepgram raw response when utterances empty: %s", response.text)
+
+    raw_segments = _extract_raw_segments(response_payload)
 
     # 연속된 같은 화자 발화 병합 후 최종 응답 포맷으로 변환
     merged = merge_consecutive_speaker_segments(raw_segments)
@@ -104,3 +116,101 @@ async def transcribe(
         }
         for i, seg in enumerate(merged)
     ]
+
+
+def _extract_raw_segments(response_payload: dict) -> list[dict]:
+    results = response_payload.get("results") or {}
+    utterances = results.get("utterances") or []
+    raw_segments = [
+        {
+            "speaker": utt.get("speaker", 0),
+            "start": utt.get("start", 0.0),
+            "end": utt.get("end", 0.0),
+            "text": (utt.get("transcript") or "").strip(),
+        }
+        for utt in utterances
+        if (utt.get("transcript") or "").strip()
+    ]
+    if raw_segments:
+        return raw_segments
+
+    alternative = _primary_alternative(response_payload)
+    words = alternative.get("words") or []
+    word_segments = _segments_from_words(words)
+    if word_segments:
+        return word_segments
+
+    transcript = (alternative.get("transcript") or "").strip()
+    if transcript:
+        return [
+            {
+                "speaker": 0,
+                "start": 0.0,
+                "end": 0.0,
+                "text": transcript,
+            }
+        ]
+    return []
+
+
+def _segments_from_words(words: list[dict]) -> list[dict]:
+    segments: list[dict] = []
+    current: dict | None = None
+    for word in words:
+        text = _word_text(word)
+        if not text:
+            continue
+        speaker = word.get("speaker")
+        if speaker is None:
+            speaker = 0
+        start = _float_or_zero(word.get("start"))
+        end = _float_or_zero(word.get("end"))
+        if current is None or current["speaker"] != speaker:
+            current = {
+                "speaker": speaker,
+                "start": start,
+                "end": end,
+                "text": text,
+            }
+            segments.append(current)
+            continue
+        current["end"] = end
+        current["text"] = f"{current['text']} {text}".strip()
+    return segments
+
+
+def _word_text(word: dict) -> str:
+    return str(word.get("punctuated_word") or word.get("word") or "").strip()
+
+
+def _float_or_zero(value: object) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _response_diagnostics(response_payload: dict) -> dict[str, int]:
+    results = response_payload.get("results") or {}
+    utterances = results.get("utterances") or []
+    channels = results.get("channels") or []
+    alternative = _primary_alternative(response_payload)
+    transcript = alternative.get("transcript") or ""
+    words = alternative.get("words") or []
+    return {
+        "utterance_count": len(utterances),
+        "channel_count": len(channels),
+        "transcript_chars": len(transcript),
+        "word_count": len(words),
+    }
+
+
+def _primary_alternative(response_payload: dict) -> dict:
+    results = response_payload.get("results") or {}
+    channels = results.get("channels") or []
+    if not channels:
+        return {}
+    alternatives = channels[0].get("alternatives") or []
+    if not alternatives:
+        return {}
+    return alternatives[0]

--- a/app/domains/transcribe/services/live_transcript_merge.py
+++ b/app/domains/transcribe/services/live_transcript_merge.py
@@ -86,7 +86,7 @@ def merge_live_transcript(
 ) -> list[TranscribeSegment]:
     # STT 결과와 WebSocket 발화 로그를 매칭해 최종 전사를 보강
     live_entries = _prepare_live_entries(live_messages)
-    if not segments or not live_entries:
+    if not live_entries:
         logger.info(
             "live transcript merge skipped: "
             "segments=%s live_messages=%s live_entries=%s",
@@ -95,6 +95,20 @@ def merge_live_transcript(
             len(live_entries),
         )
         return segments
+    if not segments:
+        logger.warning(
+            "live transcript merge falling back to WebSocket-only transcript: "
+            "segments=%s live_messages=%s live_entries=%s",
+            len(segments),
+            len(live_messages),
+            len(live_entries),
+        )
+        return _apply_matches(
+            segments,
+            live_entries,
+            matches={},
+            speaker_mapping={},
+        )
 
     matches = _match_segments_to_live_messages(segments, live_entries)
     speaker_mapping = _resolve_speaker_mapping(segments, live_entries, matches)

--- a/tests/test_deepgram_response_parsing.py
+++ b/tests/test_deepgram_response_parsing.py
@@ -1,0 +1,155 @@
+from app.domains.transcribe.services.deepgram import (
+    _extract_raw_segments,
+    _response_diagnostics,
+)
+
+
+def test_extract_raw_segments_prefers_utterances():
+    payload = {
+        "results": {
+            "utterances": [
+                {
+                    "speaker": 1,
+                    "start": 1.0,
+                    "end": 3.0,
+                    "transcript": "회의 분석을 시작합니다",
+                }
+            ],
+            "channels": [
+                {
+                    "alternatives": [
+                        {
+                            "transcript": "무시되어야 하는 전체 transcript",
+                            "words": [
+                                {
+                                    "speaker": 0,
+                                    "start": 1.0,
+                                    "end": 1.2,
+                                    "word": "무시",
+                                }
+                            ],
+                        }
+                    ]
+                }
+            ],
+        }
+    }
+
+    segments = _extract_raw_segments(payload)
+
+    assert segments == [
+        {
+            "speaker": 1,
+            "start": 1.0,
+            "end": 3.0,
+            "text": "회의 분석을 시작합니다",
+        }
+    ]
+
+
+def test_extract_raw_segments_falls_back_to_words_when_utterances_are_empty():
+    payload = {
+        "results": {
+            "utterances": [],
+            "channels": [
+                {
+                    "alternatives": [
+                        {
+                            "transcript": "회의 분석 결과를 확인합니다",
+                            "words": [
+                                {
+                                    "speaker": 0,
+                                    "start": 0.0,
+                                    "end": 0.3,
+                                    "punctuated_word": "회의",
+                                },
+                                {
+                                    "speaker": 0,
+                                    "start": 0.3,
+                                    "end": 0.6,
+                                    "punctuated_word": "분석",
+                                },
+                                {
+                                    "speaker": 1,
+                                    "start": 1.0,
+                                    "end": 1.4,
+                                    "word": "확인합니다",
+                                },
+                            ],
+                        }
+                    ]
+                }
+            ],
+        }
+    }
+
+    segments = _extract_raw_segments(payload)
+
+    assert segments == [
+        {
+            "speaker": 0,
+            "start": 0.0,
+            "end": 0.6,
+            "text": "회의 분석",
+        },
+        {
+            "speaker": 1,
+            "start": 1.0,
+            "end": 1.4,
+            "text": "확인합니다",
+        },
+    ]
+
+
+def test_extract_raw_segments_falls_back_to_channel_transcript():
+    payload = {
+        "results": {
+            "utterances": [],
+            "channels": [
+                {
+                    "alternatives": [
+                        {
+                            "transcript": "발화 단위는 없지만 전체 전사는 존재합니다",
+                            "words": [],
+                        }
+                    ]
+                }
+            ],
+        }
+    }
+
+    segments = _extract_raw_segments(payload)
+
+    assert segments == [
+        {
+            "speaker": 0,
+            "start": 0.0,
+            "end": 0.0,
+            "text": "발화 단위는 없지만 전체 전사는 존재합니다",
+        }
+    ]
+
+
+def test_response_diagnostics_counts_deepgram_result_shapes():
+    payload = {
+        "results": {
+            "utterances": [{"transcript": "하나"}],
+            "channels": [
+                {
+                    "alternatives": [
+                        {
+                            "transcript": "하나 둘",
+                            "words": [{"word": "하나"}, {"word": "둘"}],
+                        }
+                    ]
+                }
+            ],
+        }
+    }
+
+    assert _response_diagnostics(payload) == {
+        "utterance_count": 1,
+        "channel_count": 1,
+        "transcript_chars": 4,
+        "word_count": 2,
+    }

--- a/tests/test_live_transcript_merge.py
+++ b/tests/test_live_transcript_merge.py
@@ -436,6 +436,37 @@ def test_merge_live_transcript_uses_websocket_only_when_no_stt_matches():
     ]
 
 
+def test_merge_live_transcript_uses_websocket_only_when_stt_is_empty():
+    live_messages = [
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=9,
+            fromMemberId=1,
+            fromName="김준용",
+            timestamp="00:00:06",
+            text="싱가포르 회의 내용을 공유하겠습니다",
+        ),
+        LiveTranscriptMessage(
+            type="TEXT",
+            meetingId=9,
+            fromMemberId=2,
+            fromName="유상완",
+            timestamp="00:00:15",
+            text="WebSocket 발화 로그 기준으로 분석을 이어가겠습니다",
+        ),
+    ]
+
+    merged = merge_live_transcript([], live_messages)
+
+    assert [segment.member_id for segment in merged] == [1, 2]
+    assert [segment.speaker for segment in merged] == ["김준용", "유상완"]
+    assert [segment.start_time for segment in merged] == ["00:00:06", "00:00:15"]
+    assert [segment.text for segment in merged] == [
+        "싱가포르 회의 내용을 공유하겠습니다",
+        "WebSocket 발화 로그 기준으로 분석을 이어가겠습니다",
+    ]
+
+
 def test_merge_live_transcript_global_match_prevents_greedy_steal():
     segments = [
         _segment(1, "Speaker 0", "00:00:00", "웹소켓 로그 확인"),


### PR DESCRIPTION
## 작업 내용
- Deepgram 응답 진단 로그 추가
  - utterances/channels/transcript/words 카운트 기록
  - utterances가 비어 있을 때 Deepgram raw response 전문 로그 기록
- `results.utterances`가 비어도 `words` 또는 전체 `transcript` 기반으로 전사 세그먼트 생성
- STT 세그먼트가 0개이고 WebSocket 발화 로그가 있으면 WebSocket-only 전사로 회의 분석 진행
- Deepgram 응답 파싱 및 WebSocket-only 폴백 회귀 테스트 추가

## 확인
- `uv run pytest tests/test_deepgram_response_parsing.py tests/test_live_transcript_merge.py`
- `uv run ruff check app/domains/transcribe/services/deepgram.py app/domains/transcribe/services/live_transcript_merge.py tests/test_deepgram_response_parsing.py tests/test_live_transcript_merge.py`
- `uv run pytest`
- `uv run ruff check`
- commit 전 diff 기준 blocking code review 수행


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * 음성 인식 응답이 불완전할 때 더 견고한 폴백 처리로 안정성 개선
  * 음성 인식 결과 없을 때 실시간 발화만으로 전사 생성 기능 추가
  * 음성 인식 처리 중 진단 정보 로깅으로 문제 추적 개선

* **Tests**
  * 응답 파싱 로직 테스트 추가
  * 실시간 병합 로직 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->