### PR TITLE
[fix/#73] 커밋 추천 범용 토큰 과매칭 완화

### DIFF
--- a/app/domains/meeting_analysis/services/matching_scoring.py
+++ b/app/domains/meeting_analysis/services/matching_scoring.py
@@ -21,21 +21,44 @@ _GENERIC_STOPWORDS = {
     "changes",
     "code",
     "commit",
+    "component",
+    "components",
     "config",
+    "data",
+    "detail",
+    "details",
     "feature",
     "feat",
+    "field",
+    "fields",
     "fix",
     "hotfix",
+    "id",
     "improve",
     "issue",
+    "item",
+    "list",
     "minor",
+    "page",
+    "pages",
     "patch",
     "refactor",
+    "request",
+    "response",
+    "result",
+    "results",
+    "screen",
+    "state",
+    "status",
     "test",
     "text",
     "title",
+    "view",
+    "views",
     "todo",
+    "ui",
     "update",
+    "user",
     "work",
     "summary",
     "변경요약",
@@ -44,15 +67,39 @@ _GENERIC_STOPWORDS = {
     "기술키워드",
     "근거",
     "적용사항",
+    "공통",
+    "관리",
+    "관련",
+    "구조",
     "기능",
+    "기반",
+    "데이터",
     "개선",
     "구현",
+    "구체화",
+    "결과",
     "수정",
+    "방식",
+    "사용자",
+    "상세",
+    "상태",
+    "서비스",
+    "요청",
+    "응답",
     "작업",
     "적용",
+    "정보",
     "정리",
     "테스트",
     "추가",
+    "커밋",
+    "컴포넌트",
+    "클라이언트",
+    "페이지",
+    "필드",
+    "항목",
+    "화면",
+    "회의",
     "변경",
     "도입",
     "삭제",
@@ -65,29 +112,69 @@ _MODULE_STOPWORDS = {
     "app",
     "build",
     "config",
+    "component",
+    "components",
     "controller",
     "core",
+    "commit",
+    "data",
     "domain",
     "dto",
     "helper",
+    "id",
+    "impl",
     "lib",
     "main",
     "model",
+    "page",
+    "pages",
     "repo",
     "repository",
+    "result",
+    "results",
+    "screen",
     "service",
     "src",
+    "state",
+    "status",
     "test",
     "tests",
     "text",
     "title",
     "utils",
+    "ui",
+    "view",
+    "views",
     "변경요약",
     "변경방향",
     "파일맥락",
     "기술키워드",
     "근거",
     "적용사항",
+    "공통",
+    "관리",
+    "관련",
+    "구조",
+    "기반",
+    "데이터",
+    "구체화",
+    "결과",
+    "방식",
+    "사용자",
+    "상세",
+    "상태",
+    "서비스",
+    "요청",
+    "응답",
+    "정보",
+    "커밋",
+    "컴포넌트",
+    "클라이언트",
+    "페이지",
+    "필드",
+    "항목",
+    "화면",
+    "회의",
 }
 
 _ABSTRACT_COMMIT_WORDS = {
@@ -404,6 +491,26 @@ def extract_module_tokens(text: str, csv_modules: str | None = None) -> set[str]
     }
 
 
+def _scoreable_keyword_tokens(tokens: set[str]) -> set[str]:
+    return {
+        normalized
+        for token in tokens
+        if (normalized := _normalize_token(token))
+        and len(normalized) >= 2
+        and normalized not in _GENERIC_STOPWORDS
+    }
+
+
+def _scoreable_module_tokens(tokens: set[str]) -> set[str]:
+    return {
+        normalized
+        for token in tokens
+        if (normalized := _normalize_token(token))
+        and len(normalized) >= 2
+        and normalized not in _MODULE_STOPWORDS
+    }
+
+
 def is_opposite_direction(
     application_labels: set[str],
     commit_labels: set[str],
@@ -436,7 +543,10 @@ def score_keyword_match(
     application_keywords: set[str],
     commit_keywords: set[str],
 ) -> int:
-    overlap_count = len(application_keywords & commit_keywords)
+    overlap_count = len(
+        _scoreable_keyword_tokens(application_keywords)
+        & _scoreable_keyword_tokens(commit_keywords)
+    )
     if overlap_count <= 0:
         return 0
     if overlap_count == 1:
@@ -450,6 +560,8 @@ def score_context_match(
     application_modules: set[str],
     commit_modules: set[str],
 ) -> int:
+    application_modules = _scoreable_module_tokens(application_modules)
+    commit_modules = _scoreable_module_tokens(commit_modules)
     if not application_modules or not commit_modules:
         return 0
 

--- a/tests/test_application_commit_matching_scoring.py
+++ b/tests/test_application_commit_matching_scoring.py
@@ -93,6 +93,35 @@ class TestKeywordScorePolicy:
         )
         assert score == 30
 
+    def test_generic_keyword_overlap_does_not_raise_score(self):
+        score = score_keyword_match(
+            {"id", "사용자", "회의", "페이지", "컴포넌트"},
+            {"id", "사용자", "회의", "페이지", "컴포넌트"},
+        )
+
+        assert score == 0
+
+    def test_domain_keyword_overlap_scores_without_generic_tokens(self):
+        score = score_keyword_match(
+            {"jwt", "토큰", "인증", "id", "사용자"},
+            {"jwt", "토큰", "id", "사용자"},
+        )
+
+        assert score == 25
+
+    def test_loading_spinner_keyword_beats_generic_ui_overlap(self):
+        generic_score = score_keyword_match(
+            {"로딩", "스피너", "컴포넌트", "페이지"},
+            {"state", "컴포넌트", "페이지"},
+        )
+        spinner_score = score_keyword_match(
+            {"로딩", "스피너", "컴포넌트", "페이지"},
+            {"로딩", "ui"},
+        )
+
+        assert generic_score == 0
+        assert spinner_score == 15
+
 
 class TestContextScorePolicy:
     def test_same_domain_folder_returns_20(self):
@@ -109,6 +138,52 @@ class TestContextScorePolicy:
     def test_unrelated_context_returns_0(self):
         score = score_context_match({"billing"}, {"auth", "token"})
         assert score == 0
+
+    def test_generic_module_overlap_does_not_raise_score(self):
+        score = score_context_match(
+            {"id", "commit", "page", "state"},
+            {"id", "commit", "page", "state"},
+        )
+
+        assert score == 0
+
+    def test_domain_module_overlap_scores_without_generic_tokens(self):
+        score = score_context_match(
+            {"jwt", "id"},
+            {"jwt", "id", "commit"},
+        )
+
+        assert score == 10
+
+
+class TestTokenExtractionPolicy:
+    def test_extract_tech_keywords_filters_generic_ui_and_identity_tokens(self):
+        keywords = extract_tech_keywords(
+            "JWT 기반 토큰 인증 방식 도입 사용자 id 회의 페이지 컴포넌트"
+        )
+
+        assert {"jwt", "토큰", "인증"} <= keywords
+        assert (
+            not {
+                "id",
+                "사용자",
+                "회의",
+                "페이지",
+                "컴포넌트",
+                "기반",
+                "방식",
+            }
+            & keywords
+        )
+
+    def test_extract_module_tokens_keeps_compound_ids_and_filters_parts(self):
+        modules = extract_module_tokens(
+            "",
+            "commit,id,page,state,jwt,auth,member_id,application_id",
+        )
+
+        assert {"jwt", "auth", "member_id", "application_id"} <= modules
+        assert not {"commit", "id", "page", "state"} & modules
 
 
 class TestTotalScorePolicy:


### PR DESCRIPTION
## 작업 내용
- id, 사용자, 회의, 페이지, 컴포넌트 등 범용 토큰이 키워드/모듈 점수를 과하게 올리지 않도록 필터 보강
- JWT, 인증, 토큰, 로딩, 스피너, Swagger 등 핵심 도메인 토큰은 유지
- 범용 토큰 과매칭 회귀 테스트 추가

## 테스트
- uv run pytest

Closes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 키워드 매칭 정확도를 향상했습니다. 제네릭 및 일반적인 용어를 필터링하여 의미 있는 키워드만 비교합니다.
  * 모듈 매칭 로직을 개선했습니다. 중복된 일반 모듈을 제외하고 도메인별 관련성을 정확히 계산합니다.

* **테스트**
  * 키워드 및 모듈 필터링 정책에 대한 검증 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->